### PR TITLE
[AJA-248] Add(mock): mock controller

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -8,5 +8,5 @@ checkstyle {
     maxWarnings = 0
     configFile = file("config/checkstyle/naver-checkstyle-rules.xml")
     configProperties = ["suppressionFile": "config/checkstyle/naver-checkstyle-suppressions.xml"]
-    toolVersion = "8.24"
+    toolVersion = "10.12.2"
 }

--- a/jacoco-exclude-class
+++ b/jacoco-exclude-class
@@ -1,3 +1,4 @@
 exclude com/newbarams/ajaja/AjajaApplication
 exclude com/newbarams/ajaja/global/config/*
 exclude com/newbarams/ajaja/global/common/*
+exclude com/newbarams/ajaja/global/mock/*

--- a/src/main/java/com/newbarams/ajaja/global/config/CorsConfig.java
+++ b/src/main/java/com/newbarams/ajaja/global/config/CorsConfig.java
@@ -1,0 +1,48 @@
+package com.newbarams.ajaja.global.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+	private static final String FRONT_LOCAL_ENV = "http://localhost:3000/";
+
+	private final List<String> allowedMethods = List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH");
+
+	@Bean
+	CorsConfigurationSource corsConfigurationSource() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+		source.registerCorsConfiguration("/**", defaultCorsConfig());
+		source.registerCorsConfiguration("/mock/**", mockCorsConfig());
+		
+		return source;
+	}
+
+	private CorsConfiguration defaultCorsConfig() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.setAllowedOrigins(List.of(FRONT_LOCAL_ENV)); // will update
+		configuration.setAllowedMethods(allowedMethods);
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+
+		return configuration;
+	}
+
+	private CorsConfiguration mockCorsConfig() {
+		CorsConfiguration configuration = new CorsConfiguration();
+
+		configuration.setAllowedOrigins(List.of(FRONT_LOCAL_ENV));
+		configuration.setAllowedMethods(allowedMethods);
+		configuration.addAllowedHeader("*");
+		configuration.setAllowCredentials(true);
+
+		return configuration;
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/config/CorsConfig.java
+++ b/src/main/java/com/newbarams/ajaja/global/config/CorsConfig.java
@@ -17,32 +17,26 @@ public class CorsConfig {
 	@Bean
 	CorsConfigurationSource corsConfigurationSource() {
 		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-
 		source.registerCorsConfiguration("/**", defaultCorsConfig());
 		source.registerCorsConfiguration("/mock/**", mockCorsConfig());
-		
 		return source;
 	}
 
 	private CorsConfiguration defaultCorsConfig() {
 		CorsConfiguration configuration = new CorsConfiguration();
-
 		configuration.setAllowedOrigins(List.of(FRONT_LOCAL_ENV)); // will update
 		configuration.setAllowedMethods(allowedMethods);
 		configuration.addAllowedHeader("*");
 		configuration.setAllowCredentials(true);
-
 		return configuration;
 	}
 
 	private CorsConfiguration mockCorsConfig() {
 		CorsConfiguration configuration = new CorsConfiguration();
-
 		configuration.setAllowedOrigins(List.of(FRONT_LOCAL_ENV));
 		configuration.setAllowedMethods(allowedMethods);
 		configuration.addAllowedHeader("*");
 		configuration.setAllowCredentials(true);
-
 		return configuration;
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/config/SecurityConfig.java
+++ b/src/main/java/com/newbarams/ajaja/global/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.newbarams.ajaja.global.config;
 
-import java.util.List;
+import static org.springframework.security.config.Customizer.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,9 +11,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
@@ -24,25 +21,11 @@ public class SecurityConfig {
 	}
 
 	@Bean
-	CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration configuration = new CorsConfiguration();
-
-		configuration.setAllowedOrigins(List.of("http://localhost:3000/"));
-		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
-		configuration.addAllowedHeader("*");
-		configuration.setAllowCredentials(true);
-
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", configuration);
-		return source;
-	}
-
-	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		http
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.csrf(AbstractHttpConfigurer::disable)
-			.cors(httpSecurityCorsConfigurer -> corsConfigurationSource())
+			.cors(withDefaults())
 			.headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 

--- a/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
+++ b/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
@@ -1,0 +1,133 @@
+package com.newbarams.ajaja.global.mock;
+
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "mock", description = "MOCK API")
+@RestController
+@RequestMapping("/mock")
+class MockController {
+	private static final String CERTIFICATION = "123456";
+	private static final String ACCESS_TOKEN = "thisismockkakaoaccesstoken";
+	private static final String REFRESH_TOKEN = "thisismockkakaorefreshtoken";
+	private static final String NEW_ACCESS_TOKEN = "thisisnewmockkakaoaccesstoken";
+	private static final List<String> nicknames =
+		Arrays.asList("노래부르는 다람쥐", "부끄러워하는 코끼리", "춤추는 강아지", "고백하는 고양이 ", "거절하는 거북이 ", "손을 번쩍든 오리");
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 회원가입 API")
+	@PostMapping("/signup")
+	@ResponseStatus(OK)
+	void signup() {
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 로그인 API")
+	@PostMapping("/login")
+	@ResponseStatus(OK)
+	Map<String, String> login() {
+		return new HashMap<>() {{
+			put("accessToken", ACCESS_TOKEN);
+			put("refreshToken", REFRESH_TOKEN);
+		}};
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 Token 재발급 API")
+	@PostMapping("/reissue")
+	@ResponseStatus(OK)
+	Map<String, String> reissue(@RequestHeader(AUTHORIZATION) String refreshToken) {
+		String token = extractToken(refreshToken);
+		validateRefreshToken(token);
+
+		return new HashMap<>() {{
+			put("accessToken", NEW_ACCESS_TOKEN);
+		}};
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 로그아웃 API")
+	@PostMapping("/logout")
+	@ResponseStatus(OK)
+	void logout() {
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 닉네임 새고로침 API")
+	@PostMapping("/users/refresh")
+	@ResponseStatus(OK)
+	Map<String, String> refreshNickname(@RequestHeader(AUTHORIZATION) String accessToken) {
+		String token = extractToken(accessToken);
+		validateAccessToken(token);
+
+		Collections.shuffle(nicknames);
+		return new HashMap<>() {{
+			put("nickname", nicknames.get(0));
+		}};
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 이메일 인증 요청 API")
+	@PostMapping("/users/send-verification")
+	@ResponseStatus(OK)
+	Map<String, String> sendVerification(@RequestHeader(AUTHORIZATION) String accessToken) {
+		String token = extractToken(accessToken);
+		validateAccessToken(token);
+
+		return new HashMap<>() {{
+			put("certification", CERTIFICATION);
+		}};
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 이메일 인증 확인 API")
+	@PostMapping("/users/verify-email")
+	@ResponseStatus(OK)
+	void verifyEmail(@RequestBody String certification) {
+		if (!CERTIFICATION.equals(certification)) {
+			throw new IllegalArgumentException("wrong certification");
+		}
+	}
+
+	@Tag(name = "mock")
+	@Operation(description = "가짜 회원탈퇴 API")
+	@DeleteMapping("/users")
+	@ResponseStatus(OK)
+	void withdraw(@RequestHeader(AUTHORIZATION) String accessToken) {
+		String token = extractToken(accessToken);
+		validateAccessToken(token);
+	}
+
+	private String extractToken(String token) {
+		return token.substring("Bearer ".length());
+	}
+
+	private void validateAccessToken(String accessToken) {
+		if (!ACCESS_TOKEN.equals(accessToken)) {
+			throw new IllegalArgumentException("wrong access token");
+		}
+	}
+
+	private void validateRefreshToken(String refreshToken) {
+		if (!ACCESS_TOKEN.equals(refreshToken)) {
+			throw new IllegalArgumentException("wrong refresh token");
+		}
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
+++ b/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
@@ -28,8 +28,8 @@ class MockController {
 	private static final String ACCESS_TOKEN = "thisismockkakaoaccesstoken";
 	private static final String REFRESH_TOKEN = "thisismockkakaorefreshtoken";
 	private static final String NEW_ACCESS_TOKEN = "thisisnewmockkakaoaccesstoken";
-	private static final List<String> nicknames =
-		Arrays.asList("노래부르는 다람쥐", "부끄러워하는 코끼리", "춤추는 강아지", "고백하는 고양이 ", "거절하는 거북이 ", "손을 번쩍든 오리");
+	private static final List<String> nicknames = Arrays.asList("노래부르는 다람쥐", "부끄러워하는 코끼리", "춤추는 강아지", "고백하는 고양이 ",
+		"거절하는 거북이 ", "손을 번쩍든 오리");
 
 	@Tag(name = "mock")
 	@Operation(description = "가짜 회원가입 API")
@@ -43,10 +43,10 @@ class MockController {
 	@PostMapping("/login")
 	@ResponseStatus(OK)
 	Map<String, String> login() {
-		return new HashMap<>() {{
-			put("accessToken", ACCESS_TOKEN);
-			put("refreshToken", REFRESH_TOKEN);
-		}};
+		Map<String, String> response = new HashMap<>();
+		response.put("accessToken", ACCESS_TOKEN);
+		response.put("refreshToken", REFRESH_TOKEN);
+		return response;
 	}
 
 	@Tag(name = "mock")
@@ -57,9 +57,9 @@ class MockController {
 		String token = extractToken(refreshToken);
 		validateRefreshToken(token);
 
-		return new HashMap<>() {{
-			put("accessToken", NEW_ACCESS_TOKEN);
-		}};
+		Map<String, String> response = new HashMap<>();
+		response.put("accessToken", NEW_ACCESS_TOKEN);
+		return response;
 	}
 
 	@Tag(name = "mock")
@@ -78,9 +78,9 @@ class MockController {
 		validateAccessToken(token);
 
 		Collections.shuffle(nicknames);
-		return new HashMap<>() {{
-			put("nickname", nicknames.get(0));
-		}};
+		Map<String, String> response = new HashMap<>();
+		response.put("nickname", nicknames.get(0));
+		return response;
 	}
 
 	@Tag(name = "mock")
@@ -91,9 +91,9 @@ class MockController {
 		String token = extractToken(accessToken);
 		validateAccessToken(token);
 
-		return new HashMap<>() {{
-			put("certification", CERTIFICATION);
-		}};
+		Map<String, String> response = new HashMap<>();
+		response.put("certification", CERTIFICATION);
+		return response;
 	}
 
 	@Tag(name = "mock")


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- user mock 컨트롤러를 구현했습니다.
- mock 전용 cors 설정을 구현했습니다.
- checkstyle 버전을 최신 버전으로 업데이트 했습니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- mock 컨트롤러를 따로 빼둠으로 한 곳에서 관리할 수 있도록 했습니다.
- mock 컨트롤러는 순수 개발용으로 프론트의 로컬 영역에서만 다룰 수 있도록 cors 설정을 했습니다.
- checkstyle 버전을 업그레이드하면서 (8.2.4 -> 10.12.2) record 이슈에 대응했습니다.