### PR TITLE
[AJA-344] Add(.src): 예외 처리 구조 설계

### DIFF
--- a/src/main/java/com/newbarams/ajaja/global/common/error/AjajaErrorCode.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/error/AjajaErrorCode.java
@@ -1,0 +1,21 @@
+package com.newbarams.ajaja.global.common.error;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum AjajaErrorCode {
+	// 400
+	BEAN_VALIDATE_FAIL_EXCEPTION(BAD_REQUEST, "올바르지 않은 데이터입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	AjajaErrorCode(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/common/error/ErrorResponse.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/error/ErrorResponse.java
@@ -1,0 +1,13 @@
+package com.newbarams.ajaja.global.common.error;
+
+import org.springframework.http.HttpStatus;
+
+public record ErrorResponse(
+	HttpStatus httpStatus,
+	String ErrorName,
+	String ErrorMessage
+) {
+	public static ErrorResponse from(AjajaErrorCode errorCode) {
+		return new ErrorResponse(errorCode.getHttpStatus(), errorCode.name(), errorCode.getMessage());
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/common/exeption/AjajaException.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/exeption/AjajaException.java
@@ -1,0 +1,30 @@
+package com.newbarams.ajaja.global.common.exeption;
+
+import com.newbarams.ajaja.global.common.error.AjajaErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class AjajaException extends RuntimeException {
+	private final AjajaErrorCode errorCode;
+
+	public AjajaException(AjajaErrorCode errorCode) {
+		this.errorCode = errorCode;
+	}
+
+	private AjajaException(String message, AjajaErrorCode errorCode) {
+		super(message);
+		this.errorCode = errorCode;
+	}
+
+	public static AjajaException withId(Long id, AjajaErrorCode errorCode) {
+		String message = errorCode.getMessage() + " Wrong with Id :" + id;
+
+		return new AjajaException(message, errorCode);
+	}
+
+	public AjajaException(String message, Throwable cause, AjajaErrorCode errorCode) {
+		super(message, cause);
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/common/exeption/GlobalExceptionHandler.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/exeption/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.newbarams.ajaja.global.common.exeption;
+
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.newbarams.ajaja.global.common.error.AjajaErrorCode;
+import com.newbarams.ajaja.global.common.error.ErrorResponse;
+
+import jakarta.validation.ConstraintViolationException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	@ExceptionHandler(AjajaException.class)
+	public ErrorResponse handleAjajaException(AjajaException exception) {
+		AjajaErrorCode errorCode = exception.getErrorCode();
+
+		return ErrorResponse.from(errorCode);
+	}
+
+	@ExceptionHandler(ConstraintViolationException.class)
+	public ErrorResponse handleValidationException(ConstraintViolationException exception) {
+		return ErrorResponse.from(AjajaErrorCode.BEAN_VALIDATE_FAIL_EXCEPTION);
+	}
+}


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 예외 처리 구조를 설계하였습니다!
- 예외 핸들러를 추가하였습니다!

# 😋 To Reviewer
- 플라이웨이에 ErrorCode 클래스가 이미 있어서 AjajaErrorCode로 네이밍하였습니다.
- 커스텀 ErrorResponse를 사용하여서 응답을 통일하였습니다. (status, 예외 이름 , 예외 메세지)
- ResponseEntity는 직관성을 떨어뜨리고 코드의 양이 늘어난다고 생각해서 사용하지 않았습니다.
- 커스텀 예외에는 직관적인 예외 생성을 보여주기 위해 롬복 생성자를 사용하지 않았습니다.