### PR TITLE
[AJA-314] Add(.user): 유저 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 
     // Fixture-Monkey
     testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:0.6.8'
+
+    // Embedded Redis
+    testImplementation 'it.ozimov:embedded-redis:0.7.3'
 }
 
 configurations {

--- a/gradle/lombok.gradle
+++ b/gradle/lombok.gradle
@@ -5,4 +5,7 @@ configurations {
 dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/src/main/java/com/newbarams/ajaja/infra/ses/MailForm.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/MailForm.java
@@ -1,0 +1,45 @@
+package com.newbarams.ajaja.infra.ses;
+
+import static org.apache.commons.codec.CharEncoding.*;
+
+import com.amazonaws.services.simpleemail.model.Body;
+import com.amazonaws.services.simpleemail.model.Content;
+import com.amazonaws.services.simpleemail.model.Destination;
+import com.amazonaws.services.simpleemail.model.Message;
+import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+@Builder
+@RequiredArgsConstructor
+class MailForm {
+	private static final String FROM_AJAJA = "no-reply@ajaja.com";
+
+	private final String to;
+	private final String subject;
+	private final String content;
+
+	public SendEmailRequest toSesForm() {
+		return new SendEmailRequest()
+			.withSource(FROM_AJAJA)
+			.withDestination(generateDestination())
+			.withMessage(generateMessage());
+	}
+
+	private Destination generateDestination() {
+		return new Destination().withToAddresses(to);
+	}
+
+	private Message generateMessage() {
+		return new Message()
+			.withSubject(withDefaultCharset(subject))
+			.withBody(new Body().withHtml(withDefaultCharset(content)));
+	}
+
+	private Content withDefaultCharset(String text) {
+		return new Content()
+			.withCharset(UTF_8)
+			.withData(text);
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/infra/ses/SesSendCertificationService.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/SesSendCertificationService.java
@@ -1,0 +1,35 @@
+package com.newbarams.ajaja.infra.ses;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.newbarams.ajaja.module.user.application.SendCertificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+class SesSendCertificationService implements SendCertificationService {
+	private final AmazonSimpleEmailService amazonSimpleEmailService;
+
+	@Async
+	@Override
+	public void send(String email, String certification) {
+		MailForm mailForm = createMail(email, certification);
+		amazonSimpleEmailService.sendEmail(mailForm.toSesForm());
+		log.info("[SES] Email Sent To : {}", email);
+	}
+
+	private MailForm createMail(String email, String certification) {
+		return MailForm.builder()
+			.to(email)
+			.content("다음 인증 번호를 입력해주세요.\n인증번호 : " + certification)
+			.subject("올해도 아좌좌 서비스 이메일 인증 메일입니다.")
+			.build();
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/SendCertificationService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/SendCertificationService.java
@@ -1,0 +1,8 @@
+package com.newbarams.ajaja.module.user.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface SendCertificationService {
+	void send(String email, String certification);
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailService.java
@@ -1,0 +1,35 @@
+package com.newbarams.ajaja.module.user.application;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SendVerificationEmailService {
+	private static final long VERIFICATION_EMAIL_EXPIRE_IN = 10 * 60 * 1000L; // 10분
+	private static final String KEY_PREFIX = "AJAJA ";
+
+	private final SendCertificationService sendCertificationService;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void sendVerification(String email) {
+		String certification = RandomCertificationGenerator.generate();
+		sendCertificationService.send(email, certification);
+		saveVerificationOnCache(email, certification);
+	}
+
+	private void saveVerificationOnCache(String email, String certification) {
+		redisTemplate.opsForValue().set(
+			KEY_PREFIX + email,
+			certification,
+			VERIFICATION_EMAIL_EXPIRE_IN,
+			TimeUnit.MILLISECONDS
+		);
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/common/RedisBasedTest.java
+++ b/src/test/java/com/newbarams/ajaja/common/RedisBasedTest.java
@@ -1,0 +1,19 @@
+package com.newbarams.ajaja.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Integration Test With Embedded Redis
+ */
+@Import(TestRedisConfig.class)
+@SpringBootTest
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RedisBasedTest {
+}

--- a/src/test/java/com/newbarams/ajaja/common/TestRedisConfig.java
+++ b/src/test/java/com/newbarams/ajaja/common/TestRedisConfig.java
@@ -1,0 +1,32 @@
+package com.newbarams.ajaja.common;
+
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.boot.test.context.TestConfiguration;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import redis.embedded.RedisServer;
+
+@Slf4j
+@RequiredArgsConstructor
+@TestConfiguration
+public class TestRedisConfig {
+	private final RedisProperties properties;
+
+	private RedisServer redisServer;
+
+	@PostConstruct
+	public void redisServer() {
+		redisServer = new RedisServer(properties.getPort());
+		redisServer.start();
+	}
+
+	@PreDestroy
+	public void stopRedis() {
+		if (redisServer != null) {
+			redisServer.stop();
+		}
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailServiceTest.java
@@ -1,0 +1,42 @@
+package com.newbarams.ajaja.module.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.newbarams.ajaja.common.RedisBasedTest;
+
+@RedisBasedTest
+class SendVerificationEmailServiceTest {
+	@Autowired
+	private SendVerificationEmailService sendVerificationEmailService;
+
+	@MockBean
+	private SendCertificationService sendCertificationService;
+
+	@Autowired
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Test
+	@DisplayName("이메일 인증 메일을 전송하면 cache에 잘 저장되어야 한다.")
+	void sendVerification_Success_SavedOnRedis() {
+		// given
+		String prefix = "AJAJA ";
+		String email = "gmlwh124@Naver.com";
+
+		// when
+		sendVerificationEmailService.sendVerification(email);
+
+		// then
+		then(sendCertificationService).should(times(1)).send(any(), any());
+
+		Object saved = redisTemplate.opsForValue().get(prefix + email);
+		assertThat(saved).isNotNull();
+		assertThat(saved).isInstanceOf(String.class);
+	}
+}


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 이메일 인증 메일을 전송하는 PR입니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 외부 Infra를 사용하기 때문에 DIP를 적용해서 구현했습니다.
- 인증 번호는 Redis에 저장되는데 이를 위한 테스트 설정도 해주었습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] sendVerification_Success_SavedOnRedis

<!-- 관련 이슈
프론트에서 작성해준 이슈와 연관되는 PR이라면 
주석을 풀고 작성해주세요! --> 

[//]: # (# 🫡 관련 Issue )
