### PR TITLE
[AJA-375] Add(.jwt): 토큰 제거기 구현

### DIFF
--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtRemover.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtRemover.java
@@ -1,0 +1,17 @@
+package com.newbarams.ajaja.global.security.jwt.util;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtRemover {
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final JwtSecretProvider jwtSecretProvider;
+
+	public void remove(Long userId) {
+		redisTemplate.delete(jwtSecretProvider.getSignature() + userId);
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtSecretProvider.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtSecretProvider.java
@@ -15,9 +15,12 @@ class JwtSecretProvider {
 	private final SecretKey secretKey;
 	private final String signature;
 
-	public JwtSecretProvider(@Value("${secret.jwt.key}") String key) {
+	public JwtSecretProvider(
+		@Value("${secret.jwt.key}") String key,
+		@Value("${secret.jwt.signature}") String signature
+	) {
 		byte[] keyBytes = Decoders.BASE64.decode(key);
 		this.secretKey = Keys.hmacShaKeyFor(keyBytes);
-		this.signature = "ajaja";
+		this.signature = signature;
 	}
 }

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -1,6 +1,7 @@
 secret:
   jwt:
     key: ENC(pJyY2N352qhAcC5/6lWtro6d+For9hI/cbua7SMbP121jsewpaMHYz4z22zwo+w4blILvGWLuSsVh7fb8bbx4Gi3YAwoCv3rXOuXQikAt4o=)
+    signature: ENC(6FZdAAIi2htp3OwQzOqnmK5tbtNLVvGO)
 
   kakao:
     client-id: ENC(KMVPUvKK/JMme0fEig2wKRfjWBiYfWS/liyB2Q0La3y7wAkI6JhjaoXnX2DdxX9J)

--- a/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtRemoverTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtRemoverTest.java
@@ -1,0 +1,41 @@
+package com.newbarams.ajaja.global.security.jwt.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.newbarams.ajaja.common.MonkeySupport;
+import com.newbarams.ajaja.common.RedisBasedTest;
+
+@RedisBasedTest
+class JwtRemoverTest extends MonkeySupport {
+	@Autowired
+	private JwtRemover jwtRemover;
+
+	@Autowired
+	private JwtGenerator jwtGenerator;
+
+	@Autowired
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Autowired
+	private JwtSecretProvider jwtSecretProvider;
+
+	@Test
+	@DisplayName("JWT를 제거하면 캐시에 아무것도 조회되지 않아야 한다.")
+	void remove_Success() {
+		// given
+		Long userId = monkey.giveMeOne(Long.class);
+		jwtGenerator.generate(userId);
+
+		// when
+		jwtRemover.remove(userId);
+
+		// then
+		assertThat(redisTemplate.opsForValue().get(jwtSecretProvider.getSignature() + userId)).isNull();
+	}
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -25,6 +25,7 @@ jasypt:
 secret:
   jwt:
     key: thisisfortestthisisfortestthisisfortestthisisfortestthisisfortestthisisfortestthisisfortest
+    signature: thisisfortest
 
   kakao:
     client-id: thisisfortest


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 토큰 제거기를 구현했습니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 애플리케이션 내부에서 JWT를 생성할 때 사인하는 값이 노출되어 있어서 암호화해서 관리하도록 수정했습니다. (사실 JWT가 보안성이 높나요? 라고 물어보면 아니긴 합니다 + 이미 깃 히스토리에 노출되어 있긴함 🥹)
- 이 Remover는 로그아웃 시에 캐시에서 특정 유저의 Refresh 토큰을 제거합니다. 캐시 덕분에 DB에 특별 테이블을 반영할 필요가 없어졌습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] remove_Success

<!-- 관련 이슈
프론트에서 작성해준 이슈와 연관되는 PR이라면 
주석을 풀고 작성해주세요! --> 

[//]: # (# 🫡 관련 Issue )
