### PR TITLE
[AJA-441] Update(.src): 메인 페이지 목 컨트롤러 아이콘 정보 추가

### DIFF
--- a/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
+++ b/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.newbarams.ajaja.global.common.AjajaResponse;
 import com.newbarams.ajaja.module.feedback.domain.dto.GetAchieve;
 import com.newbarams.ajaja.module.feedback.domain.dto.UpdateFeedback;
-import com.newbarams.ajaja.module.plan.dto.PlanInfoResponse;
 import com.newbarams.ajaja.module.plan.dto.PlanRequest;
 import com.newbarams.ajaja.module.plan.dto.PlanResponse;
 import com.newbarams.ajaja.module.remind.domain.dto.GetReminds;
@@ -283,14 +282,15 @@ class MockController {
 	@Operation(summary = "[테스트] 메인 페이지 API")
 	@GetMapping("/plans/main/{userId}")
 	@ResponseStatus(OK)
-	public AjajaResponse<PlanInfoResponse.GetPlanInfoResponse> getPlanInfo(@PathVariable Long userId) {
-		List<PlanInfoResponse.GetGetPlan> getPlan = List.of(
-			new PlanInfoResponse.GetGetPlan("매일 운동하기", true, 90),
-			new PlanInfoResponse.GetGetPlan("매일 코딩하기", true, 90),
-			new PlanInfoResponse.GetGetPlan("매일 아침 9시에 일어나기", false, 20)
+	public AjajaResponse<MockPlanInfoResponse.GetPlanInfoResponse> getPlanInfo(@PathVariable Long userId) {
+		List<MockPlanInfoResponse.GetPlan> getPlan = List.of(
+			new MockPlanInfoResponse.GetPlan("매일 운동하기", true, 90, 1),
+			new MockPlanInfoResponse.GetPlan("매일 코딩하기", true, 90, 2),
+			new MockPlanInfoResponse.GetPlan("매일 아침 9시에 일어나기", false, 20, 3)
 		);
 
-		PlanInfoResponse.GetPlanInfoResponse getPlanInfo = new PlanInfoResponse.GetPlanInfoResponse(50, getPlan);
+		MockPlanInfoResponse.GetPlanInfoResponse getPlanInfo = new MockPlanInfoResponse.GetPlanInfoResponse(50,
+			getPlan);
 		return new AjajaResponse<>(true, getPlanInfo);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/mock/MockPlanInfoResponse.java
+++ b/src/main/java/com/newbarams/ajaja/global/mock/MockPlanInfoResponse.java
@@ -1,0 +1,20 @@
+package com.newbarams.ajaja.global.mock;
+
+import java.util.List;
+
+public sealed interface MockPlanInfoResponse permits MockPlanInfoResponse.GetPlanInfoResponse,
+	MockPlanInfoResponse.GetPlan {
+	record GetPlanInfoResponse(
+		int totalAchieveRate,
+		List<GetPlan> getPlanList
+	) implements MockPlanInfoResponse {
+	}
+
+	record GetPlan(
+		String title,
+		boolean isRemindable,
+		int achieveRate,
+		int icon
+	) implements MockPlanInfoResponse {
+	}
+}


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 메인 페이지 목 컨트롤러에 아이콘 정보를 int 형으로 추가했습니다!
![image](https://github.com/New-Barams/This-Year-Ajaja-BE/assets/102570281/8085459a-33fe-43e6-97ec-776a1b7eeda1)


# 😋 To Reviewer
- 당장 필드에 아이콘을 추가하긴 어려워서 목 dto를 하나 만들었습니다.
