### PR TITLE
[AJA-368] Add(.user): 로그아웃 구현

### DIFF
--- a/src/main/java/com/newbarams/ajaja/module/user/application/LogoutService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/LogoutService.java
@@ -1,0 +1,31 @@
+package com.newbarams.ajaja.module.user.application;
+
+import static com.newbarams.ajaja.global.common.error.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newbarams.ajaja.global.common.exception.AjajaException;
+import com.newbarams.ajaja.global.security.jwt.util.JwtRemover;
+import com.newbarams.ajaja.module.user.domain.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LogoutService {
+	private final UserRepository userRepository;
+	private final JwtRemover jwtRemover;
+
+	public void logout(Long id) {
+		validateExist(id);
+		jwtRemover.remove(id);
+	}
+
+	private void validateExist(Long id) {
+		if (!userRepository.existsById(id)) {
+			throw new AjajaException(USER_NOT_FOUND);
+		}
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/User.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/User.java
@@ -58,4 +58,8 @@ public class User extends BaseEntity<User> {
 	public String getEmail() {
 		return email.getEmail();
 	}
+
+	public void delete() {
+		this.isDeleted = true;
+	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/UserRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+
+	boolean existsById(Long id);
 }

--- a/src/test/java/com/newbarams/ajaja/common/JpaTestSupport.java
+++ b/src/test/java/com/newbarams/ajaja/common/JpaTestSupport.java
@@ -1,0 +1,15 @@
+package com.newbarams.ajaja.common;
+
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import com.newbarams.ajaja.global.config.QuerydslConfig;
+
+/**
+ * Supporting Jpa Slice Test With Monkey And Querydsl
+ * @author hejow
+ */
+@DataJpaTest
+@Import(QuerydslConfig.class)
+public abstract class JpaTestSupport extends MonkeySupport {
+}

--- a/src/test/java/com/newbarams/ajaja/common/RedisBasedTest.java
+++ b/src/test/java/com/newbarams/ajaja/common/RedisBasedTest.java
@@ -7,12 +7,14 @@ import java.lang.annotation.Target;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Integration Test With Embedded Redis
  */
 @Import(TestRedisConfig.class)
-@SpringBootTest
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RedisBasedTest {

--- a/src/test/java/com/newbarams/ajaja/module/user/application/LogoutServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/LogoutServiceTest.java
@@ -1,0 +1,53 @@
+package com.newbarams.ajaja.module.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.newbarams.ajaja.common.MockTestSupport;
+import com.newbarams.ajaja.global.common.exception.AjajaException;
+import com.newbarams.ajaja.global.security.jwt.util.JwtRemover;
+import com.newbarams.ajaja.module.user.domain.UserRepository;
+
+class LogoutServiceTest extends MockTestSupport {
+	@InjectMocks
+	private LogoutService logoutService;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private JwtRemover jwtRemover;
+
+	@Test
+	@DisplayName("사용자가 로그아웃하면 토큰이 삭제되어야 한다.")
+	void logout_Success_ThenTokenRemoved() {
+		// given
+		Long userId = monkey.giveMeOne(Long.class);
+		given(userRepository.existsById(any())).willReturn(true);
+
+		// when
+		logoutService.logout(userId);
+
+		// then
+		then(userRepository).should(times(1)).existsById(any());
+		then(jwtRemover).should(times(1)).remove(any());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 사용자를 로그아웃시키면 예외를 던진다.")
+	void logout_Fail_ByNotExistUser() {
+		// given
+		Long userId = monkey.giveMeOne(Long.class);
+		given(userRepository.existsById(any())).willReturn(false);
+
+		// when, then
+		assertThatExceptionOfType(AjajaException.class)
+			.isThrownBy(() -> logoutService.logout(userId));
+		then(jwtRemover).shouldHaveNoInteractions();
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/user/domain/UserRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/domain/UserRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.newbarams.ajaja.module.user.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.newbarams.ajaja.common.JpaTestSupport;
+
+class UserRepositoryTest extends JpaTestSupport {
+	@Autowired
+	private UserRepository userRepository;
+
+	private User user;
+
+	@BeforeEach
+	void setup() {
+		Email email = new Email("gmlwh124@naver.com");
+		user = monkey.giveMeBuilder(User.class)
+			.set("email", email)
+			.set("isDeleted", false)
+			.sample();
+	}
+
+	@Test
+	@DisplayName("회원탈퇴되지 않은 유저를 조회하면 정상적으로 조회되어야 한다.")
+	void existById_Success_ByNotDeletedUser() {
+		// given
+		User saved = userRepository.save(user);
+
+		// when
+		boolean shouldBeTrue = userRepository.existsById(saved.getId());
+
+		// then
+		assertThat(shouldBeTrue).isTrue();
+	}
+
+	@Test
+	@DisplayName("회원탈퇴한 유저를 조회하면 아무것도 조회되지 않아야 한다.")
+	void existById_Fail_ByDeletedUser() {
+		// given
+		user.delete();
+		User saved = userRepository.save(user);
+
+		// when
+		boolean shouldBeFalse = userRepository.existsById(saved.getId());
+
+		// then
+		assertThat(shouldBeFalse).isFalse();
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:test;MODE=MySQL
+    url: jdbc:h2:mem:test;MODE=MySQL;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -12,7 +12,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.H2Dialect
     open-in-view: false
 
   flyway:


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 로그아웃 기능을 구현했습니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- JPA 관련 테스트를 진행할 때 필요한 TestSupport를 도입했습니다. 그리고 @SpringBootTest에 대해서는 병렬적으로 테스트가 수행될 수 있게 RandomPort를 반영하였습니다.
- 사용자가 존재하는지 확인하기 위한 query method를 추가하였습니다.
- 로그아웃 기능이 구현되었고 이제 aws의 ElastiCache를 추가할 생각입니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] existById_Success_ByNotDeletedUser
- [x] existById_Fail_ByDeletedUser
- [x] logout_Success_ThenTokenRemoved
- [x] logout_Fail_ByNotExistUser
