### PR TITLE
[AJA-438] Add(.src) : 시즌일 때 리마인드 정보 불러오기 API 구현

### DIFF
--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
@@ -142,4 +142,32 @@ public class Plan extends BaseEntity<Plan> {
 	public String getTimeName() {
 		return info.getTimeName();
 	}
+
+	public int getRemindTime() {
+		return info.getRemindTime();
+	}
+
+	public int getRemindMonth() {
+		return info.getRemindMonth();
+	}
+
+	public int getRemindDate() {
+		return info.getRemindDate();
+	}
+
+	public int getRemindTerm() {
+		return info.getRemindTerm();
+	}
+
+	public int getRemindTotalPeriod() {
+		return info.getRemindTotalPeriod();
+	}
+
+	public boolean getIsRemindable() {
+		return status.isCanRemind();
+	}
+
+	public int getTotalRemindNumber() {
+		return info.getTotalRemindNumber();
+	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/RemindInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/RemindInfo.java
@@ -58,16 +58,6 @@ public class RemindInfo extends SelfValidating<RemindInfo> {
 		return this.remindTerm == 1 ? totalRemindNumber - 1 : totalRemindNumber;
 	}
 
-	public int getRemindTime(String name) {
-		if (name.equals("MORNING")) {
-			return 9;
-		} else if (name.equals("AFTERNOON")) {
-			return 13;
-		} else {
-			return 22;
-		}
-	}
-
 	public int getRemindTime() {
 		String name = this.remindTime.name();
 

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/RemindInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/RemindInfo.java
@@ -17,7 +17,20 @@ public class RemindInfo extends SelfValidating<RemindInfo> {
 	enum RemindTime {
 		MORNING,
 		AFTERNOON,
-		EVENING
+		EVENING;
+
+		public int getRemindTime() {
+			String name = this.name();
+
+			if (name.equals("MORNING")) {
+				return 9;
+			} else if (name.equals("AFTERNOON")) {
+				return 13;
+			} else {
+				return 22;
+			}
+		}
+
 	}
 
 	@Positive
@@ -48,6 +61,10 @@ public class RemindInfo extends SelfValidating<RemindInfo> {
 		this.validateSelf();
 	}
 
+	public int getRemindTime() {
+		return remindTime.getRemindTime();
+	}
+
 	public int getRemindMonth() {
 		return this.remindTerm == 1 ? 2 : this.remindTerm;
 	}
@@ -56,18 +73,6 @@ public class RemindInfo extends SelfValidating<RemindInfo> {
 		int totalRemindNumber = this.remindTotalPeriod / this.remindTerm;
 
 		return this.remindTerm == 1 ? totalRemindNumber - 1 : totalRemindNumber;
-	}
-
-	public int getRemindTime() {
-		String name = this.remindTime.name();
-
-		if (name.equals("MORNING")) {
-			return 9;
-		} else if (name.equals("AFTERNOON")) {
-			return 13;
-		} else {
-			return 22;
-		}
 	}
 
 	public String getTimeName() {

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/RemindInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/RemindInfo.java
@@ -68,6 +68,18 @@ public class RemindInfo extends SelfValidating<RemindInfo> {
 		}
 	}
 
+	public int getRemindTime() {
+		String name = this.remindTime.name();
+
+		if (name.equals("MORNING")) {
+			return 9;
+		} else if (name.equals("AFTERNOON")) {
+			return 13;
+		} else {
+			return 22;
+		}
+	}
+
 	public String getTimeName() {
 		return remindTime.name();
 	}

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/CreateRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/CreateRemindService.java
@@ -31,7 +31,7 @@ public class CreateRemindService {
 
 		while (remindMonth <= totalPeriod) {
 			Info info = new Info(messageIterator.next().getContent());
-			int remindTime = remindInfo.getRemindTime(remindInfo.getTimeName());
+			int remindTime = remindInfo.getRemindTime();
 
 			Instant time = parseInstant(remindInfo.getRemindDate(), remindMonth, remindTime);
 

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/GetRemindInfoService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/GetRemindInfoService.java
@@ -48,7 +48,7 @@ public class GetRemindInfoService {
 		String remindTime = plan.getTimeName(); // todo: 디미터의 법칙
 
 		return new GetRemindInfo.CommonResponse(
-			plan.getInfo().getRemindTime(remindTime),
+			plan.getInfo().getRemindTime(),
 			plan.getInfo().getRemindDate(),
 			plan.getInfo().getRemindTerm(),
 			plan.getInfo().getRemindTotalPeriod(),

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoService.java
@@ -1,0 +1,30 @@
+package com.newbarams.ajaja.module.remind.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newbarams.ajaja.module.plan.application.LoadPlanService;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.remind.domain.dto.GetRemindInfo;
+import com.newbarams.ajaja.module.remind.mapper.RemindMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoadRemindInfoService {
+	private final LoadPlanService loadPlanService;
+	private final RemindMapper remindMapper;
+
+	public GetRemindInfo.CommonResponse loadRemindInfo(Long planId) {
+		Plan plan = loadPlanService.loadPlanOrElseThrow(planId);
+
+		List<GetRemindInfo.FutureRemindResponse> futureRemindResponse
+			= remindMapper.toFutureRemind(plan);
+
+		return new GetRemindInfo.CommonResponse(plan, futureRemindResponse);
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoService.java
@@ -1,7 +1,5 @@
 package com.newbarams.ajaja.module.remind.application;
 
-import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,9 +20,6 @@ public class LoadRemindInfoService {
 	public GetRemindInfo.CommonResponse loadRemindInfo(Long planId) {
 		Plan plan = loadPlanService.loadPlanOrElseThrow(planId);
 
-		List<GetRemindInfo.FutureRemindResponse> futureRemindResponse
-			= remindMapper.toFutureRemind(plan);
-
-		return new GetRemindInfo.CommonResponse(plan, futureRemindResponse);
+		return remindMapper.toFutureRemind(plan);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/remind/controller/RemindController.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/controller/RemindController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.newbarams.ajaja.global.common.AjajaResponse;
 import com.newbarams.ajaja.module.remind.application.GetRemindInfoService;
+import com.newbarams.ajaja.module.remind.application.LoadRemindInfoService;
 import com.newbarams.ajaja.module.remind.domain.dto.GetRemindInfo;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/reminds")
 public class RemindController {
 	private final GetRemindInfoService getRemindInfoService;
+	private final LoadRemindInfoService loadRemindInfoService;
 
 	@Operation(summary = "비시즌일때 리마인드 조회 API")
 	@GetMapping("/{planId}")
@@ -29,6 +31,15 @@ public class RemindController {
 		@PathVariable Long planId
 	) {
 		return new AjajaResponse<>(true, getRemindInfoService.getRemindInfo(planId));
+	}
+
+	@Operation(summary = "시즌일 때 리마인드 조회 API")
+	@GetMapping("/modify/{planId}")
+	@ResponseStatus(HttpStatus.OK)
+	public AjajaResponse<GetRemindInfo> getRemindInfoResponse(
+		@PathVariable Long planId
+	) {
+		return new AjajaResponse<>(true, loadRemindInfoService.loadRemindInfo(planId));
 	}
 
 }

--- a/src/main/java/com/newbarams/ajaja/module/remind/domain/dto/GetRemindInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/domain/dto/GetRemindInfo.java
@@ -1,6 +1,9 @@
 package com.newbarams.ajaja.module.remind.domain.dto;
 
+import java.util.Collections;
 import java.util.List;
+
+import com.newbarams.ajaja.module.plan.domain.Plan;
 
 public sealed interface GetRemindInfo
 	permits GetRemindInfo.CommonResponse, GetRemindInfo.SentRemindResponse, GetRemindInfo.FutureRemindResponse {
@@ -15,6 +18,17 @@ public sealed interface GetRemindInfo
 		List<FutureRemindResponse> futureRemindResponses
 
 	) implements GetRemindInfo {
+		public CommonResponse(Plan plan, List<FutureRemindResponse> futureRemindResponse) {
+			this(
+				plan.getRemindTime(),
+				plan.getRemindDate(),
+				plan.getRemindTerm(),
+				plan.getRemindTotalPeriod(),
+				plan.getIsRemindable(),
+				Collections.emptyList(),
+				futureRemindResponse
+			);
+		}
 	}
 
 	record SentRemindResponse(
@@ -43,5 +57,19 @@ public sealed interface GetRemindInfo
 		int endMonth,
 		int endDate
 	) implements GetRemindInfo {
+		public FutureRemindResponse(String remindMessage, int remindMonth, int remindDate) {
+			this(
+				0L,
+				remindMessage,
+				remindMonth,
+				remindDate,
+				0,
+				false,
+				false,
+				false,
+				0,
+				0
+			);
+		}
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/remind/mapper/RemindMapper.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/mapper/RemindMapper.java
@@ -12,7 +12,7 @@ import com.newbarams.ajaja.module.remind.domain.dto.GetRemindInfo;
 @Component
 public class RemindMapper {
 
-	public List<GetRemindInfo.FutureRemindResponse> toFutureRemind(
+	public GetRemindInfo.CommonResponse toFutureRemind(
 		Plan plan
 	) {
 		List<GetRemindInfo.FutureRemindResponse> futureRemindResponses = new ArrayList<>();
@@ -32,6 +32,6 @@ public class RemindMapper {
 			remindMonth += remindTerm;
 		}
 
-		return futureRemindResponses;
+		return new GetRemindInfo.CommonResponse(plan, futureRemindResponses);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/remind/mapper/RemindMapper.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/mapper/RemindMapper.java
@@ -1,0 +1,37 @@
+package com.newbarams.ajaja.module.remind.mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.newbarams.ajaja.module.plan.domain.Message;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.remind.domain.dto.GetRemindInfo;
+
+@Component
+public class RemindMapper {
+
+	public List<GetRemindInfo.FutureRemindResponse> toFutureRemind(
+		Plan plan
+	) {
+		List<GetRemindInfo.FutureRemindResponse> futureRemindResponses = new ArrayList<>();
+
+		int remindTerm = plan.getRemindTerm();
+		int remindMonth = plan.getRemindMonth();
+		List<Message> messages = plan.getMessages();
+
+		for (Message message : messages) {
+			futureRemindResponses.add(
+				new GetRemindInfo.FutureRemindResponse(
+					message.getContent(),
+					remindMonth,
+					plan.getRemindDate()
+				));
+
+			remindMonth += remindTerm;
+		}
+
+		return futureRemindResponses;
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoServiceTest.java
@@ -14,6 +14,7 @@ import com.newbarams.ajaja.common.MockTestSupport;
 import com.newbarams.ajaja.global.common.exception.AjajaException;
 import com.newbarams.ajaja.module.plan.application.LoadPlanService;
 import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.remind.domain.dto.GetRemindInfo;
 import com.newbarams.ajaja.module.remind.mapper.RemindMapper;
 
 class LoadRemindInfoServiceTest extends MockTestSupport {
@@ -29,10 +30,11 @@ class LoadRemindInfoServiceTest extends MockTestSupport {
 	void getRemindInfo_Success_WithNoException() {
 		// given
 		Plan plan = monkey.giveMeOne(Plan.class);
+		GetRemindInfo.CommonResponse response = new GetRemindInfo.CommonResponse(plan, Collections.emptyList());
 
 		// when
 		given(loadPlanService.loadPlanOrElseThrow(any())).willReturn(plan);
-		given(remindMapper.toFutureRemind(any())).willReturn(Collections.emptyList());
+		given(remindMapper.toFutureRemind(any())).willReturn(response);
 
 		// then
 		Assertions.assertThatNoException().isThrownBy(

--- a/src/test/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/remind/application/LoadRemindInfoServiceTest.java
@@ -1,0 +1,57 @@
+package com.newbarams.ajaja.module.remind.application;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.newbarams.ajaja.common.MockTestSupport;
+import com.newbarams.ajaja.global.common.exception.AjajaException;
+import com.newbarams.ajaja.module.plan.application.LoadPlanService;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.remind.mapper.RemindMapper;
+
+class LoadRemindInfoServiceTest extends MockTestSupport {
+	@InjectMocks
+	private LoadRemindInfoService loadRemindInfoService;
+	@Mock
+	private LoadPlanService loadPlanService;
+	@Mock
+	private RemindMapper remindMapper;
+
+	@Test
+	@DisplayName("계획id로 조회하면 해당 계획에 맞는 리마인드 응답을 받는다.")
+	void getRemindInfo_Success_WithNoException() {
+		// given
+		Plan plan = monkey.giveMeOne(Plan.class);
+
+		// when
+		given(loadPlanService.loadPlanOrElseThrow(any())).willReturn(plan);
+		given(remindMapper.toFutureRemind(any())).willReturn(Collections.emptyList());
+
+		// then
+		Assertions.assertThatNoException().isThrownBy(
+			() -> loadRemindInfoService.loadRemindInfo(1L)
+		);
+	}
+
+	@Test
+	void getRemindInfo_Fail_WithNoException() {
+		// given
+		Plan plan = null;
+
+		// when
+		doThrow(AjajaException.class).when(loadPlanService).loadPlanOrElseThrow(any());
+
+		// then
+		Assertions.assertThatException().isThrownBy(
+			() -> loadRemindInfoService.loadRemindInfo(1L)
+		);
+
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/remind/mapper/RemindMapperTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/remind/mapper/RemindMapperTest.java
@@ -1,7 +1,5 @@
 package com.newbarams.ajaja.module.remind.mapper;
 
-import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,10 +20,10 @@ class RemindMapperTest extends MockTestSupport {
 		Plan plan = monkey.giveMeOne(Plan.class);
 
 		// when
-		List<GetRemindInfo.FutureRemindResponse> futureRemindResponse
+		GetRemindInfo.CommonResponse futureRemindResponse
 			= remindMapper.toFutureRemind(plan);
 
 		// then
-		Assertions.assertThat(futureRemindResponse.size()).isEqualTo(plan.getMessages().size());
+		Assertions.assertThat(futureRemindResponse.futureRemindResponses().size()).isEqualTo(plan.getMessages().size());
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/module/remind/mapper/RemindMapperTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/remind/mapper/RemindMapperTest.java
@@ -1,0 +1,31 @@
+package com.newbarams.ajaja.module.remind.mapper;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+
+import com.newbarams.ajaja.common.MockTestSupport;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.remind.domain.dto.GetRemindInfo;
+
+class RemindMapperTest extends MockTestSupport {
+	@InjectMocks
+	private RemindMapper remindMapper;
+
+	@Test
+	@DisplayName("계획에 담긴 메세지의 개수만큼 리마인드 정보들을 반환한다.")
+	void getFutureRemindList_Success_WithNoException() {
+		// given
+		Plan plan = monkey.giveMeOne(Plan.class);
+
+		// when
+		List<GetRemindInfo.FutureRemindResponse> futureRemindResponse
+			= remindMapper.toFutureRemind(plan);
+
+		// then
+		Assertions.assertThat(futureRemindResponse.size()).isEqualTo(plan.getMessages().size());
+	}
+}


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 시즌(1월)일 때 리마인드 정보들을 불러오는 API를 구현했습니다!

# 😋 To Reviewer
- 현재 비시즌 , 시즌 구분없이 응답값이 통일되어 있는데 프론트에서 기능 구현이 되면 응답값을 구분할 것 같습니다.

# ✅ 작성한 테스트
- [x] getFutureRemindList_Success_WithNoException
- [x] getRemindInfo_Success_WithNoException
- [x] getRemindInfo_Fail_WithNoException