### PR TITLE
[AJA-525] 유저가 아좌좌 누른 여부 적용 안되는 것 수정

### DIFF
--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepository.java
@@ -72,7 +72,7 @@ public class PlanQueryRepository {
 	private boolean isPressAjaja(Plan plan, Long userId) {
 		Ajaja ajaja = plan.getAjajaByUserId(userId);
 
-		if (ajaja.isEqualsDefault()) {
+		if (ajaja.isEqualsDefault() || ajaja.isCanceled()) {
 			return false;
 		}
 


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 유저가 아좌좌를 누른 여부가 적용 안되는 것을 수정하였습니다.


<!-- 관련 이슈
프론트에서 작성해준 이슈와 연관되는 PR이라면 
주석을 풀고 작성해주세요! --> 

[//]: # (# 🫡 관련 Issue )
