### PR TITLE
[AJA-444] 조회된 계획 없을 시 빈 리스트 반환

### DIFF
--- a/src/main/java/com/newbarams/ajaja/module/plan/application/LoadPlanInfoService.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/application/LoadPlanInfoService.java
@@ -1,6 +1,7 @@
 package com.newbarams.ajaja.module.plan.application;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ public class LoadPlanInfoService {
 		List<PlanInfoResponse.GetPlan> planInfos = planQueryRepository.findAllPlanByUserId(userId);
 
 		if (planInfos.isEmpty()) {
-			return loadPlanInfoResponses(0, 0, planInfos);
+			return Collections.EMPTY_LIST;
 		}
 
 		int currentYear = planInfos.get(0).year();

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/LoadPlanInfoServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/LoadPlanInfoServiceTest.java
@@ -50,13 +50,11 @@ class LoadPlanInfoServiceTest extends MockTestSupport {
 	void getNoPlanInfo_Success_WithNoException() {
 		// given
 		given(planQueryRepository.findAllPlanByUserId(any())).willReturn(Collections.emptyList());
-		given(createPlanResponseService.createPlanInfo(anyInt(), any())).willReturn(null);
 
 		//when
 		List<PlanInfoResponse.GetPlanInfoResponse> planInfoResponses = loadPlanInfoService.loadPlanInfo(1L);
 
 		// then
-		then(createPlanResponseService).should(times(1)).createPlanInfo(anyInt(), any());
-		Assertions.assertThat(planInfoResponses.get(0)).isNull();
+		Assertions.assertThat(planInfoResponses).isEmpty();
 	}
 }


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 프론트 요구 사항이 변경됨에 따라 응답값을 수정하였습니다.
- 메인페이지에서 조회된 계획이 없을 시 빈 리스트가 반환되게 하였습니다.