### PR TITLE
[AJA-496] Update(.user): 회원탈퇴 로직 추가

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -11,4 +11,4 @@ checkstyle {
     toolVersion = "10.12.2"
 }
 
-checkstyleMain.exclude('com/newbarams/ajaja/module/user/auth/model/KakaoTokenRequest.java')
+checkstyleMain.exclude('com/newbarams/ajaja/module/user/kakao/model/KakaoTokenRequest.java')

--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -12,3 +12,4 @@ checkstyle {
 }
 
 checkstyleMain.exclude('com/newbarams/ajaja/module/user/kakao/model/KakaoTokenRequest.java')
+        .exclude('com/newbarams/ajaja/module/user/kakao/model/KakaoUnlinkRequest.java')

--- a/src/main/java/com/newbarams/ajaja/global/common/AjajaResponse.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/AjajaResponse.java
@@ -3,6 +3,9 @@ package com.newbarams.ajaja.global.common;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import lombok.Getter;
+
+@Getter
 @JsonPropertyOrder({"success", "data"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AjajaResponse<T> {
@@ -14,23 +17,11 @@ public class AjajaResponse<T> {
 		this.data = data;
 	}
 
-	public static AjajaResponse<Void> ok(Boolean success) {
-		return new AjajaResponse<>(success, null);
-	}
-
 	public static <T> AjajaResponse<T> ok(T data) {
 		return new AjajaResponse<>(true, data);
 	}
 
-	public static AjajaResponse<Void> noData() {
+	public static AjajaResponse<Void> ok() {
 		return new AjajaResponse<>(true, null);
-	}
-
-	public Boolean getSuccess() {
-		return success;
-	}
-
-	public T getData() {
-		return data;
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.newbarams.ajaja.global.security.jwt.filter;
 
 import static com.newbarams.ajaja.global.common.error.ErrorCode.*;
+import static com.newbarams.ajaja.global.util.BearerTokenUtil.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.HttpMethod.*;
 
@@ -23,7 +24,6 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
-	private static final String BEARER_PREFIX = "Bearer ";
 	private static final String PLAN_URI = "/plans";
 
 	private final List<String> allowList;
@@ -57,7 +57,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private String resolveJwtFromRequest(HttpServletRequest request) {
 		String token = request.getHeader(AUTHORIZATION);
 		validateBearerToken(token);
-		return resolve(token);
+		return resolveJwt(token);
 	}
 
 	private void validateBearerToken(String bearerToken) {
@@ -67,11 +67,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	private boolean isNotBearerToken(String token) {
-		return !(StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX));
-	}
-
-	private String resolve(String bearerToken) {
-		return bearerToken.substring(BEARER_PREFIX.length());
+		return !(StringUtils.hasText(token) && isBearer(token));
 	}
 
 	private void authenticate(String jwt) {

--- a/src/main/java/com/newbarams/ajaja/global/util/BearerTokenUtil.java
+++ b/src/main/java/com/newbarams/ajaja/global/util/BearerTokenUtil.java
@@ -1,0 +1,24 @@
+package com.newbarams.ajaja.global.util;
+
+import java.util.Objects;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class BearerTokenUtil {
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	public static String toBearer(String token) {
+		Objects.requireNonNull(token, "Token must be not null");
+		return BEARER_PREFIX + token;
+	}
+
+	public static boolean isBearer(String token) {
+		return token.startsWith(BEARER_PREFIX);
+	}
+
+	public static String resolveJwt(String bearerToken) {
+		return bearerToken.substring(BEARER_PREFIX.length());
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoAuthorizeFeignClient.java
+++ b/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoAuthorizeFeignClient.java
@@ -4,8 +4,8 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import com.newbarams.ajaja.module.user.auth.model.KakaoResponse;
-import com.newbarams.ajaja.module.user.auth.model.KakaoTokenRequest;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoTokenRequest;
 
 @FeignClient(name = "KakaoAuthorizeFeignClient", url = "https://kauth.kakao.com")
 public interface KakaoAuthorizeFeignClient {

--- a/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoProfileFeignClient.java
+++ b/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoProfileFeignClient.java
@@ -6,7 +6,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-import com.newbarams.ajaja.module.user.auth.model.KakaoResponse;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
 
 @FeignClient(name = "KakaoProfileFeignClient", url = "https://kapi.kakao.com")
 public interface KakaoProfileFeignClient {

--- a/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoProperties.java
+++ b/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoProperties.java
@@ -10,4 +10,6 @@ import lombok.RequiredArgsConstructor;
 @ConfigurationProperties(prefix = "secret.kakao")
 public class KakaoProperties {
 	private final String clientId;
+	private final String clientSecret;
+	private final String logoutRedirectUrl;
 }

--- a/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoProperties.java
+++ b/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoProperties.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @ConfigurationProperties(prefix = "secret.kakao")
 public class KakaoProperties {
+	private final String adminKey;
 	private final String clientId;
 	private final String clientSecret;
 	private final String logoutRedirectUrl;

--- a/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoUnlinkFeignClient.java
+++ b/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoUnlinkFeignClient.java
@@ -1,0 +1,13 @@
+package com.newbarams.ajaja.infra.feign.kakao;
+
+import static org.springframework.http.HttpHeaders.*;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "KakaoDisconnectFeignClient", url = "https://kapi.kakao.com")
+public interface KakaoUnlinkFeignClient {
+	@PostMapping("/v1/user/unlink")
+	void unlink(@RequestHeader(AUTHORIZATION) String accessToken);
+}

--- a/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoUnlinkFeignClient.java
+++ b/src/main/java/com/newbarams/ajaja/infra/feign/kakao/KakaoUnlinkFeignClient.java
@@ -4,10 +4,13 @@ import static org.springframework.http.HttpHeaders.*;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+
+import com.newbarams.ajaja.module.user.kakao.model.KakaoUnlinkRequest;
 
 @FeignClient(name = "KakaoDisconnectFeignClient", url = "https://kapi.kakao.com")
 public interface KakaoUnlinkFeignClient {
 	@PostMapping("/v1/user/unlink")
-	void unlink(@RequestHeader(AUTHORIZATION) String accessToken);
+	void unlink(@RequestHeader(AUTHORIZATION) String adminKey, @RequestBody KakaoUnlinkRequest request);
 }

--- a/src/main/java/com/newbarams/ajaja/module/plan/application/DisablePlanServiceImpl.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/application/DisablePlanServiceImpl.java
@@ -1,0 +1,24 @@
+package com.newbarams.ajaja.module.plan.application;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.plan.domain.repository.PlanQueryRepository;
+import com.newbarams.ajaja.module.user.application.DisablePlanService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@Transactional
+@RequiredArgsConstructor
+class DisablePlanServiceImpl implements DisablePlanService {
+	private final PlanQueryRepository planQueryRepository;
+
+	@Override
+	public void disable(Long userId) {
+		for (Plan plan : planQueryRepository.findAllCurrentPlansByUserId(userId)) {
+			plan.disable();
+		}
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
@@ -25,7 +25,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -60,7 +59,6 @@ public class Plan extends BaseEntity<Plan> {
 	private RemindInfo info;
 	private PlanStatus status;
 
-	@NotEmpty
 	@ElementCollection(fetch = FetchType.EAGER) // todo:메세지 로딩 오류로 인한 임시 코드 (나중에 지우기)
 	@CollectionTable(name = "remind_messages", joinColumns = @JoinColumn(name = "plan_id"))
 	@OrderColumn(name = "message_idx")
@@ -188,20 +186,16 @@ public class Plan extends BaseEntity<Plan> {
 		return status.isCanRemind();
 	}
 
-	public int getTotalRemindNumber() {
-		return info.getTotalRemindNumber();
-	}
-
 	public String getMessage(int remindTerm, int currentMonth) {
 		int messageIdx = getMessageIdx(remindTerm, currentMonth);
-
 		return this.messages.get(messageIdx).getContent();
 	}
 
 	private int getMessageIdx(int remindTerm, int currentMonth) {
-		if (remindTerm == ONE_MONTH_TERM) {
-			return currentMonth - 2;
-		}
-		return currentMonth / remindTerm;
+		return remindTerm == ONE_MONTH_TERM ? (currentMonth - 2) : currentMonth / remindTerm;
+	}
+
+	public void disable() {
+		this.status = status.disable();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/PlanStatus.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/PlanStatus.java
@@ -2,12 +2,14 @@ package com.newbarams.ajaja.module.plan.domain;
 
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PlanStatus {
 	private boolean isPublic;
 	private boolean canRemind;
@@ -15,17 +17,7 @@ public class PlanStatus {
 	private boolean isDeleted;
 
 	public PlanStatus(boolean isPublic) {
-		this.isPublic = isPublic;
-		this.canRemind = true;
-		this.canAjaja = true;
-		this.isDeleted = false;
-	}
-
-	private PlanStatus(boolean isPublic, boolean canRemind, boolean canAjaja) {
-		this.isPublic = isPublic;
-		this.canRemind = canRemind;
-		this.canAjaja = canAjaja;
-		this.isDeleted = false;
+		this(isPublic, true, true, false);
 	}
 
 	void toDeleted() {
@@ -45,6 +37,10 @@ public class PlanStatus {
 	}
 
 	PlanStatus update(boolean isPublic, boolean canRemind, boolean canAjaja) {
-		return new PlanStatus(isPublic, canRemind, canAjaja);
+		return new PlanStatus(isPublic, canRemind, canAjaja, isDeleted);
+	}
+
+	PlanStatus disable() {
+		return new PlanStatus(isPublic, false, false, true);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepository.java
@@ -138,8 +138,7 @@ public class PlanQueryRepository {
 	}
 
 	private OrderSpecifier<?> sortBy(String condition) {
-		return condition.equalsIgnoreCase(CREATED_AT) ?
-			new OrderSpecifier<>(Order.DESC, plan.createdAt) :
+		return condition.equalsIgnoreCase(CREATED_AT) ? new OrderSpecifier<>(Order.DESC, plan.createdAt) :
 			new OrderSpecifier<>(Order.DESC, plan.ajajas.size());
 	}
 

--- a/src/main/java/com/newbarams/ajaja/module/user/application/AuthorizeService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/AuthorizeService.java
@@ -2,7 +2,7 @@ package com.newbarams.ajaja.module.user.application;
 
 import org.springframework.stereotype.Service;
 
-import com.newbarams.ajaja.module.user.auth.model.AccessToken;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
 
 @Service
 public interface AuthorizeService {

--- a/src/main/java/com/newbarams/ajaja/module/user/application/DisablePlanService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/DisablePlanService.java
@@ -3,6 +3,6 @@ package com.newbarams.ajaja.module.user.application;
 import org.springframework.stereotype.Service;
 
 @Service
-public interface DisconnectService {
-	void disconnect(String authorizationCode, String redirectUri);
+public interface DisablePlanService {
+	void disable(Long userId);
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/DisconnectOauthService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/DisconnectOauthService.java
@@ -1,0 +1,8 @@
+package com.newbarams.ajaja.module.user.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface DisconnectOauthService {
+	void disconnect(String authorizationCode, String redirectUri);
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/DisconnectOauthService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/DisconnectOauthService.java
@@ -4,5 +4,5 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface DisconnectOauthService {
-	void disconnect(String authorizationCode, String redirectUri);
+	void disconnect(Long oauthId);
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/DisconnectService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/DisconnectService.java
@@ -1,0 +1,8 @@
+package com.newbarams.ajaja.module.user.application;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface DisconnectService {
+	void disconnect(String authorizationCode, String redirectUri);
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/EmailVerification.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/EmailVerification.java
@@ -1,7 +1,0 @@
-package com.newbarams.ajaja.module.user.application;
-
-record EmailVerification(
-	String email,
-	String certification
-) {
-}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/GetProfileService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/GetProfileService.java
@@ -2,7 +2,7 @@ package com.newbarams.ajaja.module.user.application;
 
 import org.springframework.stereotype.Service;
 
-import com.newbarams.ajaja.module.user.auth.model.Profile;
+import com.newbarams.ajaja.module.user.application.model.Profile;
 
 @Service
 public interface GetProfileService {

--- a/src/main/java/com/newbarams/ajaja/module/user/application/LoginService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/LoginService.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.newbarams.ajaja.global.security.jwt.util.JwtGenerator;
-import com.newbarams.ajaja.module.user.auth.model.AccessToken;
-import com.newbarams.ajaja.module.user.auth.model.Profile;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.application.model.Profile;
 import com.newbarams.ajaja.module.user.domain.User;
 import com.newbarams.ajaja.module.user.domain.repository.UserRepository;
 import com.newbarams.ajaja.module.user.dto.UserResponse;

--- a/src/main/java/com/newbarams/ajaja/module/user/application/LoginService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/LoginService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.newbarams.ajaja.global.security.jwt.util.JwtGenerator;
 import com.newbarams.ajaja.module.user.application.model.AccessToken;
 import com.newbarams.ajaja.module.user.application.model.Profile;
+import com.newbarams.ajaja.module.user.domain.OauthInfo;
 import com.newbarams.ajaja.module.user.domain.User;
 import com.newbarams.ajaja.module.user.domain.repository.UserRepository;
 import com.newbarams.ajaja.module.user.dto.UserResponse;
@@ -24,17 +25,17 @@ public class LoginService {
 	public UserResponse.Token login(String authorizationCode, String redirectUri) {
 		AccessToken accessToken = authorizeService.authorize(authorizationCode, redirectUri);
 		Profile profile = getProfileService.getProfile(accessToken.getContent());
-		User user = findUserOrCreateIfNotExists(profile.getEmail());
+		User user = findUserOrCreateIfNotExists(profile.getEmail(), profile.getInfo());
 		return jwtGenerator.generate(user.getId());
 	}
 
-	private User findUserOrCreateIfNotExists(String email) {
+	private User findUserOrCreateIfNotExists(String email, OauthInfo oauthInfo) {
 		return userRepository.findByEmail_Email(email)
-			.orElseGet(() -> createUser(email));
+			.orElseGet(() -> createUser(email, oauthInfo));
 	}
 
-	private User createUser(String email) {
-		User user = new User(RandomNicknameGenerator.generate(), email);
+	private User createUser(String email, OauthInfo oauthInfo) {
+		User user = new User(RandomNicknameGenerator.generate(), email, oauthInfo);
 		return userRepository.save(user);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailService.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.newbarams.ajaja.module.user.application.model.EmailVerification;
 import com.newbarams.ajaja.module.user.domain.User;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/newbarams/ajaja/module/user/application/VerifyCertificationService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/VerifyCertificationService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.newbarams.ajaja.global.common.exception.AjajaException;
+import com.newbarams.ajaja.module.user.application.model.EmailVerification;
 import com.newbarams.ajaja.module.user.domain.User;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/newbarams/ajaja/module/user/application/WithdrawService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/WithdrawService.java
@@ -12,9 +12,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WithdrawService {
 	private final RetrieveUserService retrieveUserService;
+	private final DisconnectService disconnectService;
 
-	public void withdraw(Long userId) {
+	public void withdraw(Long userId, String authorizationCode, String redirectUri) {
 		User user = retrieveUserService.loadExistUserById(userId);
-		user.delete(); // todo: add oauth separation, delete plans ... etc.
+		disconnectService.disconnect(authorizationCode, redirectUri);
+		user.delete(); // todo: delete plans ... etc.
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/WithdrawService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/WithdrawService.java
@@ -15,10 +15,10 @@ public class WithdrawService {
 	private final RetrieveUserService retrieveUserService;
 	private final DisconnectOauthService disconnectOauthService;
 
-	public void withdraw(Long userId, String authorizationCode, String redirectUri) {
+	public void withdraw(Long userId) {
 		User user = retrieveUserService.loadExistUserById(userId);
+		disconnectOauthService.disconnect(user.getOauthId());
 		disablePlanService.disable(userId);
-		disconnectOauthService.disconnect(authorizationCode, redirectUri);
 		user.delete();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/WithdrawService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/WithdrawService.java
@@ -11,12 +11,14 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 public class WithdrawService {
+	private final DisablePlanService disablePlanService;
 	private final RetrieveUserService retrieveUserService;
-	private final DisconnectService disconnectService;
+	private final DisconnectOauthService disconnectOauthService;
 
 	public void withdraw(Long userId, String authorizationCode, String redirectUri) {
 		User user = retrieveUserService.loadExistUserById(userId);
-		disconnectService.disconnect(authorizationCode, redirectUri);
-		user.delete(); // todo: delete plans ... etc.
+		disablePlanService.disable(userId);
+		disconnectOauthService.disconnect(authorizationCode, redirectUri);
+		user.delete();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/model/AccessToken.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/model/AccessToken.java
@@ -1,0 +1,5 @@
+package com.newbarams.ajaja.module.user.application.model;
+
+public interface AccessToken {
+	String getContent();
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/model/EmailVerification.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/model/EmailVerification.java
@@ -1,0 +1,7 @@
+package com.newbarams.ajaja.module.user.application.model;
+
+public record EmailVerification(
+	String email,
+	String certification
+) {
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/application/model/Profile.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/model/Profile.java
@@ -1,8 +1,12 @@
 package com.newbarams.ajaja.module.user.application.model;
 
+import com.newbarams.ajaja.module.user.domain.OauthInfo;
+
 /**
- * 다양한 Oauth2 대비용 추상체, 서비스에서는 유저의 이메일 정보만 필요하다.
+ * Oauth2 Interface
  */
 public interface Profile {
+	OauthInfo getInfo();
+
 	String getEmail();
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/application/model/Profile.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/model/Profile.java
@@ -1,0 +1,8 @@
+package com.newbarams.ajaja.module.user.application.model;
+
+/**
+ * 다양한 Oauth2 대비용 추상체, 서비스에서는 유저의 이메일 정보만 필요하다.
+ */
+public interface Profile {
+	String getEmail();
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/auth/model/AccessToken.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/auth/model/AccessToken.java
@@ -1,5 +1,0 @@
-package com.newbarams.ajaja.module.user.auth.model;
-
-public interface AccessToken {
-	String getContent();
-}

--- a/src/main/java/com/newbarams/ajaja/module/user/auth/model/Profile.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/auth/model/Profile.java
@@ -1,8 +1,0 @@
-package com.newbarams.ajaja.module.user.auth.model;
-
-/**
- * 다양한 Oauth2 도입 대비용 추상체, 서비스에서는 유저의 이메일 정보만 필요하다.
- */
-public interface Profile {
-	String getEmail();
-}

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/OauthInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/OauthInfo.java
@@ -7,8 +7,10 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OauthInfo extends SelfValidating<OauthInfo> {

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/OauthInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/OauthInfo.java
@@ -1,0 +1,30 @@
+package com.newbarams.ajaja.module.user.domain;
+
+import com.newbarams.ajaja.global.common.SelfValidating;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OauthInfo extends SelfValidating<OauthInfo> {
+	@NotNull
+	private Long oauthId;
+
+	@Enumerated(EnumType.STRING)
+	private OauthProvider provider;
+
+	public OauthInfo(Long oauthId, OauthProvider provider) {
+		this.oauthId = oauthId;
+		this.provider = provider;
+		this.validateSelf();
+	}
+
+	public static OauthInfo kakao(Long oauthId) {
+		return new OauthInfo(oauthId, OauthProvider.KAKAO);
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/OauthInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/OauthInfo.java
@@ -18,11 +18,11 @@ public class OauthInfo extends SelfValidating<OauthInfo> {
 	private Long oauthId;
 
 	@Enumerated(EnumType.STRING)
-	private OauthProvider provider;
+	private OauthProvider oauthProvider;
 
-	public OauthInfo(Long oauthId, OauthProvider provider) {
+	public OauthInfo(Long oauthId, OauthProvider oauthProvider) {
 		this.oauthId = oauthId;
-		this.provider = provider;
+		this.oauthProvider = oauthProvider;
 		this.validateSelf();
 	}
 

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/OauthProvider.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/OauthProvider.java
@@ -1,0 +1,5 @@
+package com.newbarams.ajaja.module.user.domain;
+
+public enum OauthProvider {
+	KAKAO;
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/User.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/User.java
@@ -82,6 +82,10 @@ public class User extends BaseEntity<User> {
 		this.receiveType = toEnum(receiveType);
 	}
 
+	public Long getOauthId() {
+		return oauthInfo.getOauthId();
+	}
+
 	private ReceiveType toEnum(String receiveType) {
 		try {
 			return ReceiveType.valueOf(receiveType.toUpperCase());

--- a/src/main/java/com/newbarams/ajaja/module/user/domain/User.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/domain/User.java
@@ -38,15 +38,17 @@ public class User extends BaseEntity<User> {
 	@Embedded
 	private Nickname nickname;
 	private Email email;
+	private OauthInfo oauthInfo;
 
 	@Enumerated(EnumType.STRING)
 	private ReceiveType receiveType;
 
 	private boolean isDeleted;
 
-	public User(String nickname, String email) {
+	public User(String nickname, String email, OauthInfo oauthInfo) {
 		this.nickname = new Nickname(nickname);
 		this.email = new Email(email);
+		this.oauthInfo = oauthInfo;
 		this.receiveType = ReceiveType.EMAIL;
 		this.isDeleted = false;
 	}

--- a/src/main/java/com/newbarams/ajaja/module/user/dto/UserRequest.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/dto/UserRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public sealed interface UserRequest permits Certification, EmailVerification, Login, Reissue {
+public sealed interface UserRequest permits Certification, EmailVerification, Login, Reissue, Withdraw {
 	record Login(
 		@NotBlank(message = "인가 코드로 빈 값이 들어올 수 없습니다.")
 		@Schema(description = "인가 코드", example = "3yZ1t-T6P0lmA51PDW0jJkKjyXazFBEKKwyoAAABi_tgGJZAPV-WDrAHcw")
@@ -41,6 +41,17 @@ public sealed interface UserRequest permits Certification, EmailVerification, Lo
 		@Pattern(regexp = "^\\d{6}$", message = "인증 번호는 6자리 숫자로 이루어져 있습니다.")
 		@Schema(description = "이메일 인증을 위해서 발급된 6자리 인증 번호")
 		String certification
+	) implements UserRequest {
+	}
+
+	record Withdraw(
+		@NotBlank(message = "인가 코드로 빈 값이 들어올 수 없습니다.")
+		@Schema(description = "인가 코드", example = "3yZ1t-T6P0lmA51PDW0jJkKjyXazFBEKKwyoAAABi_tgGJZAPV-WDrAHcw")
+		String authorizationCode,
+
+		@NotBlank(message = "리다이렉트 URL로 빈 값이 들어올 수 없습니다.")
+		@Schema(description = "리다이렉트 URL", example = "http://localhost:3000/oauth")
+		String redirectUri
 	) implements UserRequest {
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/dto/UserRequest.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/dto/UserRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-public sealed interface UserRequest permits Certification, EmailVerification, Login, Reissue, Withdraw {
+public sealed interface UserRequest permits Certification, EmailVerification, Login, Reissue {
 	record Login(
 		@NotBlank(message = "인가 코드로 빈 값이 들어올 수 없습니다.")
 		@Schema(description = "인가 코드", example = "3yZ1t-T6P0lmA51PDW0jJkKjyXazFBEKKwyoAAABi_tgGJZAPV-WDrAHcw")
@@ -41,17 +41,6 @@ public sealed interface UserRequest permits Certification, EmailVerification, Lo
 		@Pattern(regexp = "^\\d{6}$", message = "인증 번호는 6자리 숫자로 이루어져 있습니다.")
 		@Schema(description = "이메일 인증을 위해서 발급된 6자리 인증 번호")
 		String certification
-	) implements UserRequest {
-	}
-
-	record Withdraw(
-		@NotBlank(message = "인가 코드로 빈 값이 들어올 수 없습니다.")
-		@Schema(description = "인가 코드", example = "3yZ1t-T6P0lmA51PDW0jJkKjyXazFBEKKwyoAAABi_tgGJZAPV-WDrAHcw")
-		String authorizationCode,
-
-		@NotBlank(message = "리다이렉트 URL로 빈 값이 들어올 수 없습니다.")
-		@Schema(description = "리다이렉트 URL", example = "http://localhost:3000/oauth")
-		String redirectUri
 	) implements UserRequest {
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoAuthorizeService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoAuthorizeService.java
@@ -1,12 +1,12 @@
-package com.newbarams.ajaja.module.user.auth.application;
+package com.newbarams.ajaja.module.user.kakao.application;
 
 import org.springframework.stereotype.Component;
 
 import com.newbarams.ajaja.infra.feign.kakao.KakaoAuthorizeFeignClient;
 import com.newbarams.ajaja.infra.feign.kakao.KakaoProperties;
 import com.newbarams.ajaja.module.user.application.AuthorizeService;
-import com.newbarams.ajaja.module.user.auth.model.AccessToken;
-import com.newbarams.ajaja.module.user.auth.model.KakaoTokenRequest;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoTokenRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,6 +23,11 @@ class KakaoAuthorizeService implements AuthorizeService {
 	}
 
 	private KakaoTokenRequest generateRequest(String authorizationCode, String redirectUri) {
-		return new KakaoTokenRequest(kakaoProperties.getClientId(), redirectUri, authorizationCode);
+		return new KakaoTokenRequest(
+			kakaoProperties.getClientId(),
+			redirectUri,
+			authorizationCode,
+			kakaoProperties.getClientSecret()
+		);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthService.java
@@ -1,26 +1,30 @@
 package com.newbarams.ajaja.module.user.kakao.application;
 
-import static com.newbarams.ajaja.global.util.BearerTokenUtil.*;
-
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import com.newbarams.ajaja.infra.feign.kakao.KakaoProperties;
 import com.newbarams.ajaja.infra.feign.kakao.KakaoUnlinkFeignClient;
 import com.newbarams.ajaja.module.user.application.DisconnectOauthService;
-import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoUnlinkRequest;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 class KakaoDisconnectOauthService implements DisconnectOauthService {
-	private final KakaoAuthorizeService kakaoAuthorizeService;
+	private static final String KAKAO_AK_PREFIX = "KakaoAK ";
+
 	private final KakaoUnlinkFeignClient kakaoUnlinkFeignClient;
+	private final KakaoProperties kakaoProperties;
 
 	@Async
 	@Override
-	public void disconnect(String authorizationCode, String redirectUri) {
-		AccessToken accessToken = kakaoAuthorizeService.authorize(authorizationCode, redirectUri);
-		kakaoUnlinkFeignClient.unlink(toBearer(accessToken.getContent()));
+	public void disconnect(Long oauthId) {
+		kakaoUnlinkFeignClient.unlink(kakaoHeader(), new KakaoUnlinkRequest(oauthId));
+	}
+
+	private String kakaoHeader() {
+		return KAKAO_AK_PREFIX + kakaoProperties.getAdminKey();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthService.java
@@ -6,14 +6,14 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import com.newbarams.ajaja.infra.feign.kakao.KakaoUnlinkFeignClient;
-import com.newbarams.ajaja.module.user.application.DisconnectService;
+import com.newbarams.ajaja.module.user.application.DisconnectOauthService;
 import com.newbarams.ajaja.module.user.application.model.AccessToken;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-class KakaoDisconnectService implements DisconnectService {
+class KakaoDisconnectOauthService implements DisconnectOauthService {
 	private final KakaoAuthorizeService kakaoAuthorizeService;
 	private final KakaoUnlinkFeignClient kakaoUnlinkFeignClient;
 

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectService.java
@@ -1,0 +1,26 @@
+package com.newbarams.ajaja.module.user.kakao.application;
+
+import static com.newbarams.ajaja.global.util.BearerTokenUtil.*;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.newbarams.ajaja.infra.feign.kakao.KakaoUnlinkFeignClient;
+import com.newbarams.ajaja.module.user.application.DisconnectService;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+class KakaoDisconnectService implements DisconnectService {
+	private final KakaoAuthorizeService kakaoAuthorizeService;
+	private final KakaoUnlinkFeignClient kakaoUnlinkFeignClient;
+
+	@Async
+	@Override
+	public void disconnect(String authorizationCode, String redirectUri) {
+		AccessToken accessToken = kakaoAuthorizeService.authorize(authorizationCode, redirectUri);
+		kakaoUnlinkFeignClient.unlink(toBearer(accessToken.getContent()));
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoGetProfileService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoGetProfileService.java
@@ -1,6 +1,6 @@
 package com.newbarams.ajaja.module.user.kakao.application;
 
-import java.util.Objects;
+import static com.newbarams.ajaja.global.util.BearerTokenUtil.*;
 
 import org.springframework.stereotype.Component;
 
@@ -13,13 +13,10 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 class KakaoGetProfileService implements GetProfileService {
-	private static final String BEARER_PREFIX = "Bearer ";
-
 	private final KakaoProfileFeignClient kakaoProfileFeignClient;
 
 	@Override
 	public Profile getProfile(String accessToken) {
-		Objects.requireNonNull(accessToken, "access token must be not null");
-		return kakaoProfileFeignClient.getKakaoProfile(BEARER_PREFIX + accessToken);
+		return kakaoProfileFeignClient.getKakaoProfile(toBearer(accessToken));
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoGetProfileService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/application/KakaoGetProfileService.java
@@ -1,4 +1,4 @@
-package com.newbarams.ajaja.module.user.auth.application;
+package com.newbarams.ajaja.module.user.kakao.application;
 
 import java.util.Objects;
 
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.newbarams.ajaja.infra.feign.kakao.KakaoProfileFeignClient;
 import com.newbarams.ajaja.module.user.application.GetProfileService;
-import com.newbarams.ajaja.module.user.auth.model.Profile;
+import com.newbarams.ajaja.module.user.application.model.Profile;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoAccount.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoAccount.java
@@ -1,4 +1,4 @@
-package com.newbarams.ajaja.module.user.auth.model;
+package com.newbarams.ajaja.module.user.kakao.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoResponse.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoResponse.java
@@ -1,10 +1,12 @@
-package com.newbarams.ajaja.module.user.auth.model;
+package com.newbarams.ajaja.module.user.kakao.model;
 
-import static com.newbarams.ajaja.module.user.auth.model.KakaoResponse.*;
+import static com.newbarams.ajaja.module.user.kakao.model.KakaoResponse.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.application.model.Profile;
 
 public sealed interface KakaoResponse permits Token, UserInfo {
 	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoResponse.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.newbarams.ajaja.module.user.application.model.AccessToken;
 import com.newbarams.ajaja.module.user.application.model.Profile;
+import com.newbarams.ajaja.module.user.domain.OauthInfo;
 
 public sealed interface KakaoResponse permits Token, UserInfo {
 	@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -30,6 +31,11 @@ public sealed interface KakaoResponse permits Token, UserInfo {
 		Long id,
 		KakaoAccount kakaoAccount
 	) implements KakaoResponse, Profile {
+		@Override
+		public OauthInfo getInfo() {
+			return OauthInfo.kakao(id);
+		}
+
 		@Override
 		public String getEmail() {
 			return kakaoAccount().email();

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoTokenRequest.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoTokenRequest.java
@@ -1,4 +1,4 @@
-package com.newbarams.ajaja.module.user.auth.model;
+package com.newbarams.ajaja.module.user.kakao.model;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -13,7 +13,7 @@ public class KakaoTokenRequest {
 	private String code;
 	private String client_secret;
 
-	public KakaoTokenRequest(String clientId, String redirectUri, String code) {
-		this(KAKAO_GRANT_TYPE, clientId, redirectUri, code, null);
+	public KakaoTokenRequest(String clientId, String redirectUri, String code, String clientSecret) {
+		this(KAKAO_GRANT_TYPE, clientId, redirectUri, code, clientSecret);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoUnlinkRequest.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/kakao/model/KakaoUnlinkRequest.java
@@ -1,0 +1,16 @@
+package com.newbarams.ajaja.module.user.kakao.model;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class KakaoUnlinkRequest {
+	private static final String KAKAO_TARGET_ID_TYPE = "user_id";
+
+	private String target_id_type;
+	private Long target_id;
+
+	public KakaoUnlinkRequest(Long targetId) {
+		this(KAKAO_TARGET_ID_TYPE, targetId);
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/user/presentation/UserController.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/presentation/UserController.java
@@ -95,7 +95,7 @@ public class UserController {
 		@Valid @RequestBody UserRequest.Certification request
 	) {
 		verifyCertificationService.verify(id, request.certification());
-		return AjajaResponse.noData();
+		return AjajaResponse.ok();
 	}
 
 	@Operation(summary = "[토큰 필요] 로그아웃 API", description = "발급된 사용자의 토큰을 만료시킵니다.", responses = {
@@ -121,14 +121,20 @@ public class UserController {
 		@Schema(allowableValues = {"kakao", "email", "both"}) @RequestParam String type
 	) {
 		changeReceiveTypeService.change(id, type);
-		return AjajaResponse.noData();
+		return AjajaResponse.ok();
 	}
 
-	@Operation(summary = "[토큰 필요] 회원 탈퇴 API", description = "덜 구현")
+	@Operation(summary = "[토큰 필요] 회원 탈퇴 API", description = "인가 코드를 통해서 회원 탈퇴를 진행합니다.", responses = {
+		@ApiResponse(responseCode = "200", description = "성공적으로 회원 탈퇴를 하였습니다."),
+		@ApiResponse(responseCode = "404", description = "사용자가 존재하지 않습니다."),
+	})
 	@DeleteMapping
 	@ResponseStatus(OK)
-	public AjajaResponse<Void> withdraw(@UserId Long id) {
-		withdrawService.withdraw(id);
-		return AjajaResponse.noData();
+	public AjajaResponse<Void> withdraw(
+		@UserId Long id,
+		@Valid @RequestBody UserRequest.Withdraw request
+	) {
+		withdrawService.withdraw(id, request.authorizationCode(), request.redirectUri());
+		return AjajaResponse.ok();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/user/presentation/UserController.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/presentation/UserController.java
@@ -104,10 +104,9 @@ public class UserController {
 		@ApiResponse(responseCode = "404", description = "사용자가 존재하지 않습니다."),
 	})
 	@PostMapping("/logout")
-	@ResponseStatus(OK)
-	public AjajaResponse<Void> logout(@UserId Long id) {
+	@ResponseStatus(NO_CONTENT)
+	public void logout(@UserId Long id) {
 		logoutService.logout(id);
-		return AjajaResponse.noData();
 	}
 
 	@Operation(summary = "[토큰 필요] 수신 종류 변경 API", description = "리마인드를 수신 방법을 변경합니다.", responses = {

--- a/src/main/java/com/newbarams/ajaja/module/user/presentation/UserController.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/presentation/UserController.java
@@ -126,15 +126,13 @@ public class UserController {
 
 	@Operation(summary = "[토큰 필요] 회원 탈퇴 API", description = "인가 코드를 통해서 회원 탈퇴를 진행합니다.", responses = {
 		@ApiResponse(responseCode = "200", description = "성공적으로 회원 탈퇴를 하였습니다."),
+		@ApiResponse(responseCode = "400", description = "유효하지 않은 토큰입니다. <br> 상세 정보는 응답을 확인 바랍니다."),
 		@ApiResponse(responseCode = "404", description = "사용자가 존재하지 않습니다."),
 	})
 	@DeleteMapping
 	@ResponseStatus(OK)
-	public AjajaResponse<Void> withdraw(
-		@UserId Long id,
-		@Valid @RequestBody UserRequest.Withdraw request
-	) {
-		withdrawService.withdraw(id, request.authorizationCode(), request.redirectUri());
+	public AjajaResponse<Void> withdraw(@UserId Long id) {
+		withdrawService.withdraw(id);
 		return AjajaResponse.ok();
 	}
 }

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -4,6 +4,7 @@ secret:
     signature: ENC(6FZdAAIi2htp3OwQzOqnmK5tbtNLVvGO)
 
   kakao:
+    admin-key: ENC(sFSNf8T3aiThdhCu9yHQb0bBLpVTkk/50UJpxgYhxRvk6JZ/xdcIk85OB17YboiM)
     client-id: ENC(egCrmTnMY/kGZNYJwP7O+dHISas8fVWFmO4bF9M6zkDHi02moIaexhENauQDBduD)
     client-secret: ENC(Eo3sbkxTa8NAnpb3OOhhhKMeu+O9KBpsIQsDL57wiISyA6T+wqfaaeJglbyurx3h)
     logout-redirect-url: ENC(cQFggzXPK6NQs7Aj/K1V5zlkGvJcXLtvNPsWBx7KiQ2DFxeoMi2+w41q9go7gIoHQ1pDFM+l++g=)

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -5,4 +5,5 @@ secret:
 
   kakao:
     client-id: ENC(egCrmTnMY/kGZNYJwP7O+dHISas8fVWFmO4bF9M6zkDHi02moIaexhENauQDBduD)
-    client-secret: ENC(g/sAYLisOXOhvq7eFD2z4kwI4MkHbJQQBJGXDoEOIEq87p7zZdYWMNy+OPJwb56T)
+    client-secret: ENC(Eo3sbkxTa8NAnpb3OOhhhKMeu+O9KBpsIQsDL57wiISyA6T+wqfaaeJglbyurx3h)
+    logout-redirect-url: ENC(cQFggzXPK6NQs7Aj/K1V5zlkGvJcXLtvNPsWBx7KiQ2DFxeoMi2+w41q9go7gIoHQ1pDFM+l++g=)

--- a/src/main/resources/db/migration/V12__add_ouath_info_on_user.sql
+++ b/src/main/resources/db/migration/V12__add_ouath_info_on_user.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+    ADD COLUMN oauth_id       BIGINT      NOT NULL,
+    ADD COLUMN oauth_provider VARCHAR(20) NOT NULL

--- a/src/main/resources/http/user-api.http
+++ b/src/main/resources/http/user-api.http
@@ -11,8 +11,8 @@ POST {{path}}/login
 Content-Type: application/json
 
 {
-  "authorizationCode": "3yZ1t-T6P0lmA51PDW0jJkKj4gJ85zLTijmqmiLiAQN6X8AFSnEhyXazFBEKKwyoAAABi_tgGJZAPV-WDrAHcw",
-  "redirectUrl": "http://localhost:3000/oauth"
+  "authorizationCode": "WXx4mr0d7vn-7k60QnQnK_ZWUdMNCjOGf-APGZnAp5twPUT9eVvOX_ypwPUKKcleAAABjABcxpLokopMIboAuA",
+  "redirectUri": "http://localhost:3000/oauth"
 }
 
 ###

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/DisablePlanServiceImplTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/DisablePlanServiceImplTest.java
@@ -1,0 +1,43 @@
+package com.newbarams.ajaja.module.plan.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.newbarams.ajaja.common.MockTestSupport;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.plan.domain.repository.PlanQueryRepository;
+
+class DisablePlanServiceImplTest extends MockTestSupport {
+	@InjectMocks
+	private DisablePlanServiceImpl disablePlanService;
+
+	@Mock
+	private PlanQueryRepository planQueryRepository;
+
+	@Test
+	void disable_Success() {
+		// given
+		Long userId = monkey.giveMeOne(Long.class);
+		List<Plan> plans = monkey.giveMe(Plan.class, 4);
+		given(planQueryRepository.findAllCurrentPlansByUserId(any())).willReturn(plans);
+
+		// when
+		disablePlanService.disable(userId);
+
+		// then
+		then(planQueryRepository).should(times(1)).findAllCurrentPlansByUserId(any());
+		plans.stream().map(Plan::getStatus)
+			.forEach(status -> {
+				assertThat(status.isCanRemind()).isFalse();
+				assertThat(status.isCanAjaja()).isFalse();
+				assertThat(status.isDeleted()).isTrue();
+			});
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/UpdatePlanServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/UpdatePlanServiceTest.java
@@ -19,6 +19,7 @@ import com.newbarams.ajaja.module.plan.domain.Plan;
 import com.newbarams.ajaja.module.plan.domain.RemindInfo;
 import com.newbarams.ajaja.module.plan.domain.repository.PlanRepository;
 import com.newbarams.ajaja.module.plan.dto.PlanRequest;
+import com.newbarams.ajaja.module.user.domain.OauthInfo;
 import com.newbarams.ajaja.module.user.domain.User;
 import com.newbarams.ajaja.module.user.domain.repository.UserRepository;
 
@@ -39,7 +40,7 @@ class UpdatePlanServiceTest {
 	@Test
 	@DisplayName("planId가 존재하고, 수정가능한 기간일 경우 계획을 수정할 수 있다.")
 	void updatePlan_Success() {
-		User user = new User("nickname", "abcde@naver.com");
+		User user = new User("nickname", "abcde@naver.com", OauthInfo.kakao(1L));
 		User savedUser = userRepository.save(user);
 
 		Plan plan = Plan.builder()

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.newbarams.ajaja.module.plan.domain.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.jqwik.api.Arbitraries;
+
+import com.newbarams.ajaja.module.plan.domain.Message;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.plan.domain.PlanStatus;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+
+@SpringBootTest
+@Transactional
+class PlanQueryRepositoryTest {
+	private final FixtureMonkey monkey = FixtureMonkey.builder()
+		.objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+		.register(Plan.class, fixture -> fixture.giveMeBuilder(Plan.class)
+			.set("id", Arbitraries.longs().greaterOrEqual(0))
+			.set("messages", List.of(new Message("test")))
+			.set("ajajas", Collections.EMPTY_LIST)
+		)
+		.plugin(new JakartaValidationPlugin())
+		.defaultNotNull(true)
+		.useExpressionStrictMode()
+		.build();
+
+	@Autowired
+	private PlanQueryRepository planQueryRepository;
+
+	@Autowired
+	private PlanRepository planRepository;
+
+	@Test
+	@DisplayName("올해의 계획들만 사용자의 아이디로 가져올 수 있어야 한다.")
+	void findAllCurrentPlansByUserId_Success() {
+		// given
+		int expectedSize = 4;
+		Long userId = monkey.giveMeOne(Long.class);
+
+		List<Plan> plans = monkey.giveMeBuilder(Plan.class)
+			.set("userId", userId)
+			.set("status", new PlanStatus(true))
+			.sampleList(expectedSize);
+
+		planRepository.saveAll(plans);
+
+		// when
+		List<Plan> currentPlans = planQueryRepository.findAllCurrentPlansByUserId(userId);
+
+		// then
+		assertThat(currentPlans).isNotEmpty().hasSize(expectedSize);
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import net.jqwik.api.Arbitraries;
 
+import com.newbarams.ajaja.module.plan.domain.Content;
 import com.newbarams.ajaja.module.plan.domain.Message;
 import com.newbarams.ajaja.module.plan.domain.Plan;
 import com.newbarams.ajaja.module.plan.domain.PlanStatus;
@@ -31,6 +32,8 @@ class PlanQueryRepositoryTest {
 			.set("messages", List.of(new Message("test")))
 			.set("ajajas", Collections.EMPTY_LIST)
 		)
+		.register(Content.class, fixture -> fixture.giveMeBuilder(Content.class)
+			.set("description", Arbitraries.strings().ofMaxLength(255)))
 		.plugin(new JakartaValidationPlugin())
 		.defaultNotNull(true)
 		.useExpressionStrictMode()

--- a/src/test/java/com/newbarams/ajaja/module/user/application/LoginServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/LoginServiceTest.java
@@ -13,12 +13,12 @@ import org.mockito.Mock;
 
 import com.newbarams.ajaja.common.MockTestSupport;
 import com.newbarams.ajaja.global.security.jwt.util.JwtGenerator;
-import com.newbarams.ajaja.module.user.auth.model.AccessToken;
-import com.newbarams.ajaja.module.user.auth.model.KakaoAccount;
-import com.newbarams.ajaja.module.user.auth.model.KakaoResponse;
-import com.newbarams.ajaja.module.user.auth.model.Profile;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.application.model.Profile;
 import com.newbarams.ajaja.module.user.domain.User;
 import com.newbarams.ajaja.module.user.domain.repository.UserRepository;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoAccount;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
 
 class LoginServiceTest extends MockTestSupport {
 	@InjectMocks

--- a/src/test/java/com/newbarams/ajaja/module/user/application/LoginServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/LoginServiceTest.java
@@ -15,6 +15,7 @@ import com.newbarams.ajaja.common.MockTestSupport;
 import com.newbarams.ajaja.global.security.jwt.util.JwtGenerator;
 import com.newbarams.ajaja.module.user.application.model.AccessToken;
 import com.newbarams.ajaja.module.user.application.model.Profile;
+import com.newbarams.ajaja.module.user.domain.OauthInfo;
 import com.newbarams.ajaja.module.user.domain.User;
 import com.newbarams.ajaja.module.user.domain.repository.UserRepository;
 import com.newbarams.ajaja.module.user.kakao.model.KakaoAccount;
@@ -50,7 +51,7 @@ class LoginServiceTest extends MockTestSupport {
 				.sample())
 			.sample();
 
-		private final User user = new User(RandomNicknameGenerator.generate(), email);
+		private final User user = new User(RandomNicknameGenerator.generate(), email, OauthInfo.kakao(1L));
 
 		@Test
 		@DisplayName("새로운 유저가 로그인하면 새롭게 유저 정보를 생성해야 한다.")

--- a/src/test/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/SendVerificationEmailServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 
 import com.newbarams.ajaja.common.MonkeySupport;
 import com.newbarams.ajaja.common.RedisBasedTest;
+import com.newbarams.ajaja.module.user.application.model.EmailVerification;
 import com.newbarams.ajaja.module.user.domain.Email;
 import com.newbarams.ajaja.module.user.domain.User;
 

--- a/src/test/java/com/newbarams/ajaja/module/user/application/VerifyCertificationServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/VerifyCertificationServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import com.newbarams.ajaja.common.MonkeySupport;
 import com.newbarams.ajaja.common.RedisBasedTest;
 import com.newbarams.ajaja.global.common.exception.AjajaException;
+import com.newbarams.ajaja.module.user.application.model.EmailVerification;
 import com.newbarams.ajaja.module.user.domain.Email;
 import com.newbarams.ajaja.module.user.domain.User;
 import com.newbarams.ajaja.module.user.domain.repository.UserRepository;

--- a/src/test/java/com/newbarams/ajaja/module/user/domain/UserTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/domain/UserTest.java
@@ -21,7 +21,7 @@ class UserTest extends MonkeySupport {
 		// given
 
 		// when, then
-		assertThatNoException().isThrownBy(() -> new User(nickname, input));
+		assertThatNoException().isThrownBy(() -> new User(nickname, input, OauthInfo.kakao(1L)));
 	}
 
 	@Test
@@ -70,7 +70,7 @@ class UserTest extends MonkeySupport {
 	void getEmail_Success() {
 		// given
 		String email = "gmlwh124@naver.com";
-		User user = new User(nickname, email);
+		User user = new User(nickname, email, OauthInfo.kakao(1L));
 
 		// when, then
 		assertThat(user.defaultEmail()).isEqualTo(email);
@@ -83,7 +83,7 @@ class UserTest extends MonkeySupport {
 	void updateReceive_Success_WithSupportType(String type) {
 		// given
 		String email = "gmlwh124@naver.com";
-		User user = new User(nickname, email);
+		User user = new User(nickname, email, OauthInfo.kakao(1L));
 
 		// when, then
 		assertThatNoException().isThrownBy(() -> user.updateReceive(type));
@@ -95,7 +95,7 @@ class UserTest extends MonkeySupport {
 	void updateReceive_Fail_ByNotSupportType(String type) {
 		// given
 		String email = "gmlwh124@naver.com";
-		User user = new User(nickname, email);
+		User user = new User(nickname, email, OauthInfo.kakao(1L));
 
 		// when, then
 		assertThatExceptionOfType(AjajaException.class)

--- a/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoAuthorizeServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoAuthorizeServiceTest.java
@@ -1,4 +1,4 @@
-package com.newbarams.ajaja.module.user.auth.application;
+package com.newbarams.ajaja.module.user.kakao.application;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -11,8 +11,8 @@ import org.mockito.Mock;
 import com.newbarams.ajaja.common.MockTestSupport;
 import com.newbarams.ajaja.infra.feign.kakao.KakaoAuthorizeFeignClient;
 import com.newbarams.ajaja.infra.feign.kakao.KakaoProperties;
-import com.newbarams.ajaja.module.user.auth.model.AccessToken;
-import com.newbarams.ajaja.module.user.auth.model.KakaoResponse;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
 
 class KakaoAuthorizeServiceTest extends MockTestSupport {
 	@InjectMocks

--- a/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthServiceTest.java
@@ -7,34 +7,30 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import com.newbarams.ajaja.common.MockTestSupport;
+import com.newbarams.ajaja.infra.feign.kakao.KakaoProperties;
 import com.newbarams.ajaja.infra.feign.kakao.KakaoUnlinkFeignClient;
-import com.newbarams.ajaja.module.user.application.model.AccessToken;
-import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
 
 class KakaoDisconnectOauthServiceTest extends MockTestSupport {
 	@InjectMocks
 	private KakaoDisconnectOauthService kakaoDisconnectService;
 
 	@Mock
-	private KakaoAuthorizeService kakaoAuthorizeService;
+	private KakaoUnlinkFeignClient kakaoUnlinkFeignClient;
 
 	@Mock
-	private KakaoUnlinkFeignClient kakaoUnlinkFeignClient;
+	private KakaoProperties kakaoProperties;
 
 	@Test
 	void disconnect_Success() {
 		// given
-		String authorizationCode = monkey.giveMeOne(String.class);
-		String redirectUri = monkey.giveMeOne(String.class);
-		AccessToken accessToken = monkey.giveMeOne(KakaoResponse.Token.class);
-
-		given(kakaoAuthorizeService.authorize(anyString(), anyString())).willReturn(accessToken);
+		Long oauthId = monkey.giveMeOne(Long.class);
+		String adminKey = monkey.giveMeOne(String.class);
+		given(kakaoProperties.getAdminKey()).willReturn(adminKey);
 
 		// when
-		kakaoDisconnectService.disconnect(authorizationCode, redirectUri);
+		kakaoDisconnectService.disconnect(oauthId);
 
 		// then
-		then(kakaoAuthorizeService).should(times(1)).authorize(anyString(), anyString());
-		then(kakaoUnlinkFeignClient).should(times(1)).unlink(anyString());
+		then(kakaoUnlinkFeignClient).should(times(1)).unlink(anyString(), any());
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectOauthServiceTest.java
@@ -11,9 +11,9 @@ import com.newbarams.ajaja.infra.feign.kakao.KakaoUnlinkFeignClient;
 import com.newbarams.ajaja.module.user.application.model.AccessToken;
 import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
 
-class KakaoDisconnectServiceTest extends MockTestSupport {
+class KakaoDisconnectOauthServiceTest extends MockTestSupport {
 	@InjectMocks
-	private KakaoDisconnectService kakaoDisconnectService;
+	private KakaoDisconnectOauthService kakaoDisconnectService;
 
 	@Mock
 	private KakaoAuthorizeService kakaoAuthorizeService;

--- a/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoDisconnectServiceTest.java
@@ -1,0 +1,40 @@
+package com.newbarams.ajaja.module.user.kakao.application;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.newbarams.ajaja.common.MockTestSupport;
+import com.newbarams.ajaja.infra.feign.kakao.KakaoUnlinkFeignClient;
+import com.newbarams.ajaja.module.user.application.model.AccessToken;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
+
+class KakaoDisconnectServiceTest extends MockTestSupport {
+	@InjectMocks
+	private KakaoDisconnectService kakaoDisconnectService;
+
+	@Mock
+	private KakaoAuthorizeService kakaoAuthorizeService;
+
+	@Mock
+	private KakaoUnlinkFeignClient kakaoUnlinkFeignClient;
+
+	@Test
+	void disconnect_Success() {
+		// given
+		String authorizationCode = monkey.giveMeOne(String.class);
+		String redirectUri = monkey.giveMeOne(String.class);
+		AccessToken accessToken = monkey.giveMeOne(KakaoResponse.Token.class);
+
+		given(kakaoAuthorizeService.authorize(anyString(), anyString())).willReturn(accessToken);
+
+		// when
+		kakaoDisconnectService.disconnect(authorizationCode, redirectUri);
+
+		// then
+		then(kakaoAuthorizeService).should(times(1)).authorize(anyString(), anyString());
+		then(kakaoUnlinkFeignClient).should(times(1)).unlink(anyString());
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoGetProfileServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/kakao/application/KakaoGetProfileServiceTest.java
@@ -1,4 +1,4 @@
-package com.newbarams.ajaja.module.user.auth.application;
+package com.newbarams.ajaja.module.user.kakao.application;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -10,8 +10,8 @@ import org.mockito.Mock;
 
 import com.newbarams.ajaja.common.MockTestSupport;
 import com.newbarams.ajaja.infra.feign.kakao.KakaoProfileFeignClient;
-import com.newbarams.ajaja.module.user.auth.model.KakaoResponse;
-import com.newbarams.ajaja.module.user.auth.model.Profile;
+import com.newbarams.ajaja.module.user.application.model.Profile;
+import com.newbarams.ajaja.module.user.kakao.model.KakaoResponse;
 
 class KakaoGetProfileServiceTest extends MockTestSupport {
 	@InjectMocks


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 기존에 있던 회원탈퇴에서 로직을 추가한 PR입니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 회원 탈퇴가 요청되면 Oauth를 끊도록 로직을 추가했습니다.
- 활성화되어있는 리마인드를 모두 비활성화 시킵니다. (의존성은 plan이 user를 바라보게 구성되어있습니다.)
- oauth에서 제공하는 admin key로 끊도록 구현했습니다. 그에 따라 추가적으로 저장해야할 정보가 생겨서 반영했습니다 (Flyway - v12)
- 이후 Flyway 버전을 조금 수정할 생각입니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] disconnect_Success
- [x] findAllCurrentPlansByUserId_Success