### PR TITLE
[AJA-532] Update(.src) : 리마인드 서비스에 html 이메일 폼 적용

### DIFF
--- a/gradle/checkstyle.gradle
+++ b/gradle/checkstyle.gradle
@@ -13,3 +13,5 @@ checkstyle {
 
 checkstyleMain.exclude('com/newbarams/ajaja/module/user/kakao/model/KakaoTokenRequest.java')
         .exclude('com/newbarams/ajaja/module/user/kakao/model/KakaoUnlinkRequest.java')
+        .exclude('com/newbarams/ajaja/infra/ses/template/PlanRemindTemplate.java')
+        .exclude('com/newbarams/ajaja/infra/ses/template/AjajaRemindTemplate.java')

--- a/src/main/java/com/newbarams/ajaja/global/aop/LoggingAspect.java
+++ b/src/main/java/com/newbarams/ajaja/global/aop/LoggingAspect.java
@@ -1,4 +1,4 @@
-package com.newbarams.ajaja.global.common.logger;
+package com.newbarams.ajaja.global.aop;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;

--- a/src/main/java/com/newbarams/ajaja/global/common/TimeValue.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/TimeValue.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 public class TimeValue {
 	private final Instant instant;
@@ -26,6 +27,10 @@ public class TimeValue {
 
 	public int getDate() {
 		return zonedDateTime.getDayOfMonth();
+	}
+
+	public ZonedDateTime getOneMonthLater() {
+		return ZonedDateTime.ofInstant(instant.plus(31, ChronoUnit.DAYS), ZoneId.of("Asia/Seoul"));
 	}
 
 	public Timestamp toTimeStamp() {

--- a/src/main/java/com/newbarams/ajaja/infra/ses/SesSendAjajaRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/SesSendAjajaRemindService.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class SesSendAjajaRemindService implements SendAjajaRemindService {
+class SesSendAjajaRemindService implements SendAjajaRemindService {
 	private final AmazonSimpleEmailService amazonSimpleEmailService;
 
 	@Async

--- a/src/main/java/com/newbarams/ajaja/infra/ses/SesSendAjajaRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/SesSendAjajaRemindService.java
@@ -1,5 +1,7 @@
 package com.newbarams.ajaja.infra.ses;
 
+import static com.newbarams.ajaja.infra.ses.template.AjajaRemindTemplate.*;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
@@ -15,16 +17,16 @@ public class SesSendAjajaRemindService implements SendAjajaRemindService {
 
 	@Async
 	@Override
-	public void send(String email, Long ajajaCount) {
-		MailForm remindMailForm = createMail(email, ajajaCount);
+	public void send(String email, String title, Long ajajaCount, Long planId) {
+		MailForm remindMailForm = createMail(email, title, ajajaCount, planId);
 		amazonSimpleEmailService.sendEmail(remindMailForm.toSesForm());
 	}
 
-	private MailForm createMail(String email, Long ajajaCount) {
+	private MailForm createMail(String email, String title, Long ajajaCount, Long planId) {
 		return MailForm.builder()
 			.to(email)
-			.subject("올해도 아좌좌 응원 리마인드 메일 (테스트)")
-			.content("총" + ajajaCount + "명의 유저가 당신의 계획을 응원하고 있어요!")
+			.subject("[올해도 아좌좌] \"%s\" 계획이 응원을 받았어요!".formatted(title))
+			.content(html.formatted(title, ajajaCount, planId))
 			.build();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/infra/ses/SesSendPlanRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/SesSendPlanRemindService.java
@@ -17,14 +17,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class SesSendPlanRemindService implements SendPlanRemindService {
-	private static final String FEEDBACK_LINK = "https://api.ajaja.me/feedbacks/";
+class SesSendPlanRemindService implements SendPlanRemindService {
+	private static final String FEEDBACK_LINK = "https://this-year-ajaja-fe.vercel.app/plans/";
 	private final AmazonSimpleEmailService amazonSimpleEmailService;
 
 	@Async
 	@Override
-	public void send(String email, String title, String message, Long feedbackId) {
-		String feedbackLink = FEEDBACK_LINK + feedbackId;
+	public void send(String email, String title, String message, Long planId) {
+		String feedbackLink = FEEDBACK_LINK + planId;
 
 		MailForm remindMailForm = createMail(email, title, message, feedbackLink);
 		amazonSimpleEmailService.sendEmail(remindMailForm.toSesForm());

--- a/src/main/java/com/newbarams/ajaja/infra/ses/SesSendPlanRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/SesSendPlanRemindService.java
@@ -1,13 +1,20 @@
 package com.newbarams.ajaja.infra.ses;
 
+import static com.newbarams.ajaja.infra.ses.template.PlanRemindTemplate.*;
+
+import java.time.ZonedDateTime;
+
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.newbarams.ajaja.global.common.TimeValue;
 import com.newbarams.ajaja.module.remind.application.SendPlanRemindService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SesSendPlanRemindService implements SendPlanRemindService {
@@ -16,18 +23,22 @@ public class SesSendPlanRemindService implements SendPlanRemindService {
 
 	@Async
 	@Override
-	public void send(String email, String message, Long feedbackId) {
+	public void send(String email, String title, String message, Long feedbackId) {
 		String feedbackLink = FEEDBACK_LINK + feedbackId;
 
-		MailForm remindMailForm = createMail(email, message, feedbackLink);
+		MailForm remindMailForm = createMail(email, title, message, feedbackLink);
 		amazonSimpleEmailService.sendEmail(remindMailForm.toSesForm());
 	}
 
-	private MailForm createMail(String email, String message, String feedbackLink) {
+	private MailForm createMail(String email, String title, String message, String feedbackLink) {
+		ZonedDateTime deadLine = new TimeValue().getOneMonthLater();
+
 		return MailForm.builder()
 			.to(email)
-			.subject("올해도 아좌좌 리마인드 메일 (테스트)")
-			.content("내가 남긴 메세지:\n" + message + "\n ,피드백 링크: \n" + feedbackLink)
+			.subject("[올해도 아좌좌] \"%s\" 계획에 대한 리마인드 메일입니다.".formatted(title))
+			.content(html.formatted(
+				title, message, deadLine.getMonthValue(), deadLine.getDayOfMonth(), feedbackLink
+			))
 			.build();
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/infra/ses/template/AjajaRemindTemplate.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/template/AjajaRemindTemplate.java
@@ -1,0 +1,57 @@
+package com.newbarams.ajaja.infra.ses.template;
+
+public final class AjajaRemindTemplate {
+	public static final String html = """
+			<table border="0" cellpadding="0" cellspacing="0" width="100%%" id="bodyTable">
+		       <tr>
+		         <td align="center">
+		           <table border="1" cellpadding="0" cellspacing="0" width="600" style="border-style: solid; padding: 20px; border-top-color: #f76c5e; border-width: 2px; border-top-width: 12px">
+		             <tr>
+		               <td style="border: none">
+		                 <img src="https://velog.velcdn.com/images/minw0_o/post/a0a5a3ba-e081-48b5-8c40-240eeae510a6/image.jpg" alt="올해도 아좌좌 LOGO" width="95" height="75" />
+		               </td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="box-sizing: border-box; padding-top: 20px; border: none; font-size: 20px; font-weight: 600"><font>[올해도 아좌좌] 응원 메세지 알림</font></td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="border: none; padding-top: 12px"><hr /></td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="box-sizing: border-box; padding-top: 20px; border: none">
+		                 <font>현재 나의</font>
+		                 <font color="#f76c5e" style="font-weight: 600">%s</font>
+		                 <font>계획을 %d명이 응원하고 있어요 💪🏻 </font>
+		               </td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="border: none; padding-top: 12px">
+		                 <font> =></font>
+		                 <a href="https://this-year-ajaja-fe.vercel.app/plans/%d" target="_blank" style="color: #f76c5e"><font color="#f76c5e" style="font-weight: 600">내 계획 확인하기</font></a>
+		               </td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="border: none; padding-top: 8px">
+		                 <font> =></font>
+		                 <a href="https://this-year-ajaja-fe.vercel.app/explore" target="_blank" style="color: #f76c5e"><font color="#f76c5e" style="font-weight: 600">다른 사람 계획 보러가기</font></a>
+		               </td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="border: none; box-sizing: border-box; padding-top: 20px"><hr /></td>
+		             </tr>
+		 
+		             <tr>
+		               <td style="border: none; box-sizing: border-box; padding-top: 12px">문의: ajajame@naver.com</td>
+		             </tr>
+		           </table>
+		         </td>
+		       </tr>
+		     </table>
+		""";
+}

--- a/src/main/java/com/newbarams/ajaja/infra/ses/template/PlanRemindTemplate.java
+++ b/src/main/java/com/newbarams/ajaja/infra/ses/template/PlanRemindTemplate.java
@@ -1,0 +1,82 @@
+package com.newbarams.ajaja.infra.ses.template;
+
+public final class PlanRemindTemplate {
+	public static final String html = """
+		<table border="0" cellpadding="0" cellspacing="0" width="100%%" id="bodyTable">
+		      <tr>
+		        <td align="center">
+		          <table border="1" cellpadding="0" cellspacing="0" width="600" style="border-style: solid; padding: 20px; border-top-color: #f76c5e; border-width: 2px; border-top-width: 12px">
+		            <tr>
+		              <td style="border: none">
+		                <img src="https://velog.velcdn.com/images/minw0_o/post/a0a5a3ba-e081-48b5-8c40-240eeae510a6/image.jpg" alt="올해도 아좌좌 LOGO" width="95" height="75" />
+		              </td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="box-sizing: border-box; padding-top: 20px; border: none; font-size: 20px; font-weight: 600"><font>[올해도 아좌좌] 리마인드 메세지 알림</font></td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="border: none; padding-top: 12px"><hr /></td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="box-sizing: border-box; padding-top: 20px; padding-left: 4px; border: none">
+		                <font color="#f76c5e" style="font-weight: 600">%s</font>
+		                <font>계획에 대한 리마인드 메세지입니다.</font>
+		              </td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="border: none; box-sizing: border-box; padding-top: 16px">
+		                <div
+		                  style="
+		                    box-sizing: border-box;
+		                    padding: 12px;
+		                    width: 100%%;
+		                    height: 300px;
+		                    border-style: solid;
+		                    border-radius: 12px;
+		                    border-color: #feceab;
+		                    border-width: 2px;
+		                    background-color: #fff6e9;
+		                  "
+		                >
+		                  <div style="box-sizing: border-box; padding: 12px; height: 100%%; border-style: dashed; border-radius: 12px; border-color: #feceab; border-width: 2px; background-color: #ffffff">
+		                    <font
+		                      >%s </font
+		                    >
+		                  </div>
+		                </div>
+		              </td>
+		            </tr>
+		            <tr>
+		              <td style="border: none; box-sizing: border-box; padding-top: 16px"><font>해당 계획을 잘 지키고 있으신가요 ?</font></td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="border: none; padding-top: 4px">
+		                <font>계획을 얼마나 잘 지키고 있는지 <font color="#f76c5e" style="font-weight: 600">%d월 %d일</font>까지 피드백해주세요</font>
+		              </td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="border: none; padding-top: 8px">
+		                <font> =></font>
+		                <a href="%s" target="_blank" style="color: #f76c5e"><font color="#f76c5e" style="font-weight: 600">피드백 하러가기</font></a>
+		              </td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="border: none; box-sizing: border-box; padding-top: 20px"><hr /></td>
+		            </tr>
+		  
+		            <tr>
+		              <td style="border: none; box-sizing: border-box; padding-top: 12px">문의: ajajame@naver.com</td>
+		            </tr>
+		          </table>
+		        </td>
+		      </tr>
+		    </table>
+		""";
+}

--- a/src/main/java/com/newbarams/ajaja/module/ajaja/application/SchedulingAjajaRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/ajaja/application/SchedulingAjajaRemindService.java
@@ -25,8 +25,11 @@ public class SchedulingAjajaRemindService {
 
 		for (RemindableAjaja remindableAjaja : remindableAjajas) {
 			String email = remindableAjaja.email();
+			String title = remindableAjaja.title();
+			Long planId = remindableAjaja.planId();
 			Long ajajaCount = remindableAjaja.count();
-			sendAjajaRemindService.send(email, ajajaCount);
+
+			sendAjajaRemindService.send(email, title, ajajaCount, planId);
 		}
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/module/ajaja/application/SendAjajaRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/ajaja/application/SendAjajaRemindService.java
@@ -4,5 +4,5 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface SendAjajaRemindService {
-	void send(String email, Long ajajaNumber);
+	void send(String email, String title, Long ajajaNumber, Long planId);
 }

--- a/src/main/java/com/newbarams/ajaja/module/ajaja/domain/repository/AjajaQueryRepositoryImpl.java
+++ b/src/main/java/com/newbarams/ajaja/module/ajaja/domain/repository/AjajaQueryRepositoryImpl.java
@@ -24,18 +24,23 @@ public class AjajaQueryRepositoryImpl implements AjajaQueryRepository {
 
 	public List<RemindableAjaja> findRemindableAjaja() {
 		return queryFactory.select(Projections.constructor(RemindableAjaja.class,
+				plan.content.title,
+				plan.id,
 				user.email.email.count(),
 				user.email.email
 			)).from(ajaja)
 			.join(plan).on(ajaja.targetId.eq(plan.id))
 			.join(user).on(plan.userId.eq(user.id))
-			.where(ajaja.updatedAt.after(Instant.now().minus(7, ChronoUnit.DAYS))
+			.where(plan.status.canAjaja.eq(true)
+				.and(ajaja.updatedAt.after(Instant.now().minus(7, ChronoUnit.DAYS)))
 				.and(ajaja.updatedAt.before(Instant.now()))
 				.and(ajaja.type.eq(Ajaja.Type.PLAN))
 				.and(ajaja.isCanceled.eq(false))
 				.and(plan.status.isDeleted.eq(false))
 			)
 			.groupBy(
+				plan.content.title,
+				plan.id,
 				user.email.email
 			)
 			.fetch();

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepository.java
@@ -237,6 +237,7 @@ public class PlanQueryRepository {
 				p -> new RemindMessageInfo(
 					p.get(plan).getUserId(),
 					p.get(plan).getId(),
+					p.get(plan).getContent().getTitle(),
 					p.get(user).getEmail().getEmail(),
 					p.get(plan).getMessage(p.get(plan).getRemindTerm(),
 						zonedDateTime.getMonthValue()),

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/SchedulingRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/SchedulingRemindService.java
@@ -49,7 +49,12 @@ public class SchedulingRemindService {
 		for (RemindMessageInfo remindInfo : remindMessageInfos) {
 			Long feedbackId = createFeedbackService.createFeedback(remindInfo.getUserId(), remindInfo.getPlanId());
 
-			sendPlanRemindService.send(remindInfo.getEmail(), remindInfo.getMessage(), feedbackId);
+			sendPlanRemindService.send(
+				remindInfo.getEmail(),
+				remindInfo.getTitle(),
+				remindInfo.getMessage(),
+				feedbackId
+			);
 
 			createRemindService.createRemind(remindInfo.getUserId(), remindInfo.getPlanId(), remindInfo.getMessage(),
 				remindInfo.getInfo());

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/SchedulingRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/SchedulingRemindService.java
@@ -47,13 +47,13 @@ public class SchedulingRemindService {
 
 	private void sendEmail(List<RemindMessageInfo> remindMessageInfos) {
 		for (RemindMessageInfo remindInfo : remindMessageInfos) {
-			Long feedbackId = createFeedbackService.createFeedback(remindInfo.getUserId(), remindInfo.getPlanId());
+			createFeedbackService.createFeedback(remindInfo.getUserId(), remindInfo.getPlanId());
 
 			sendPlanRemindService.send(
 				remindInfo.getEmail(),
 				remindInfo.getTitle(),
 				remindInfo.getMessage(),
-				feedbackId
+				remindInfo.getPlanId()
 			);
 
 			createRemindService.createRemind(remindInfo.getUserId(), remindInfo.getPlanId(), remindInfo.getMessage(),

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/SendPlanRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/SendPlanRemindService.java
@@ -4,5 +4,5 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface SendPlanRemindService {
-	void send(String email, String title, String message, Long feedbackId);
+	void send(String email, String title, String message, Long planId);
 }

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/SendPlanRemindService.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/SendPlanRemindService.java
@@ -4,5 +4,5 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface SendPlanRemindService {
-	void send(String email, String message, Long feedbackId);
+	void send(String email, String title, String message, Long feedbackId);
 }

--- a/src/main/java/com/newbarams/ajaja/module/remind/application/model/RemindableAjaja.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/application/model/RemindableAjaja.java
@@ -1,6 +1,8 @@
 package com.newbarams.ajaja.module.remind.application.model;
 
 public record RemindableAjaja(
+	String title,
+	Long planId,
 	Long count,
 	String email
 ) {

--- a/src/main/java/com/newbarams/ajaja/module/remind/dto/RemindMessageInfo.java
+++ b/src/main/java/com/newbarams/ajaja/module/remind/dto/RemindMessageInfo.java
@@ -8,13 +8,15 @@ import lombok.Getter;
 public class RemindMessageInfo {
 	Long userId;
 	Long planId;
+	String title;
 	String email;
 	String message;
 	RemindInfo info;
 
-	public RemindMessageInfo(Long userId, Long planId, String email, String message, RemindInfo info) {
+	public RemindMessageInfo(Long userId, Long planId, String title, String email, String message, RemindInfo info) {
 		this.userId = userId;
 		this.planId = planId;
+		this.title = title;
 		this.email = email;
 		this.message = message;
 		this.info = info;


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- 기존 텍스트로만 전송됐던 이메일에 html 폼을 적용하였습니다.

![image](https://github.com/New-Barams/This-Year-Ajaja-BE/assets/102570281/61504327-f25e-42ac-b2c2-b551707281db)

# 😋 To Reviewer
- 게더에서 논의 했던 대로 resource 에 위치하려고 했지만 파싱 오류가 자꾸 발생하여서 일단은 String 코드로 저장하였습니다.
- 추가적으로 이메일 폼에 필요한 데이터를 채우기 위해 쿼리 수정을 하였습니다.
- 그 외 슬랙에서 논의했었던 내용들을 반영하였습니다.
