### PR TITLE
Update(.jwt): separate token generating, raw parsing logic

### DIFF
--- a/src/main/java/com/newbarams/ajaja/global/common/TimeValue.java
+++ b/src/main/java/com/newbarams/ajaja/global/common/TimeValue.java
@@ -1,5 +1,6 @@
 package com.newbarams.ajaja.global.common;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -8,6 +9,7 @@ import java.util.Date;
 
 public class TimeValue {
 	private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+	private static final int THREE_DAYS = 3;
 
 	private final Instant instant;
 	private final ZonedDateTime zonedDateTime;
@@ -46,7 +48,12 @@ public class TimeValue {
 	}
 
 	public ZonedDateTime oneMonthLater() {
-		return ZonedDateTime.ofInstant(instant.plus(31, ChronoUnit.DAYS), ZoneId.of(DEFAULT_TIME_ZONE));
+		return zonedDateTime.plusMonths(1);
+	}
+
+	public boolean isWithinThreeDays(Date expireIn) {
+		Duration between = Duration.between(instant, expireIn.toInstant());
+		return Math.abs(between.toDays()) <= THREE_DAYS;
 	}
 
 	public static boolean check(Instant createdAt) {

--- a/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
+++ b/src/main/java/com/newbarams/ajaja/global/mock/MockController.java
@@ -69,7 +69,7 @@ public class MockController {
 	@PostMapping("/login")
 	@ResponseStatus(OK)
 	AjajaResponse<UserResponse.Token> login(@RequestBody UserRequest.Login request) {
-		UserResponse.Token response = jwtGenerator.generate(1L);
+		UserResponse.Token response = jwtGenerator.login(1L);
 		return AjajaResponse.ok(response);
 	}
 
@@ -78,7 +78,7 @@ public class MockController {
 	@ResponseStatus(OK)
 	AjajaResponse<UserResponse.Token> reissue(@RequestBody UserRequest.Reissue request) {
 		jwtValidator.validateReissuableAndExtractId(request.getAccessToken(), request.getRefreshToken());
-		UserResponse.Token response = jwtGenerator.generate(1L);
+		UserResponse.Token response = jwtGenerator.reissue(1L, request.getRefreshToken());
 		return AjajaResponse.ok(response);
 	}
 

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtGenerator.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtGenerator.java
@@ -14,26 +14,61 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class JwtGenerator {
+	@FunctionalInterface
+	private interface RefreshTokenGenerator {
+		String generate(Long userId, TimeValue time);
+	}
+
 	private static final long ACCESS_TOKEN_VALID_TIME = 30 * 60 * 1000L; // 30분
 	private static final long REFRESH_TOKEN_VALID_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
 
 	private final JwtSecretProvider jwtSecretProvider;
 	private final CacheUtil cacheUtil;
+	private final JwtParser parser;
 
-	public UserResponse.Token generate(Long userId) {
+	public UserResponse.Token login(Long userId) {
+		return generate(userId, this::generateRefreshToken);
+	}
+
+	public UserResponse.Token reissue(Long userId, String oldRefreshToken) {
+		return generate(userId,
+			(id, time) -> shouldReissue(oldRefreshToken, time) ? generateRefreshToken(id, time) : oldRefreshToken
+		);
+	}
+
+	private UserResponse.Token generate(Long userId, RefreshTokenGenerator generator) {
 		final TimeValue time = new TimeValue();
-		String accessToken = generateJwt(userId, time.expireIn(ACCESS_TOKEN_VALID_TIME));
-		String refreshToken = generateJwt(userId, time.expireIn(REFRESH_TOKEN_VALID_TIME));
+		String accessToken = generateAccessToken(userId, time);
+		String refreshToken = generator.generate(userId, time);
 
-		cacheUtil.saveRefreshToken(jwtSecretProvider.cacheKey(userId), refreshToken, REFRESH_TOKEN_VALID_TIME);
 		return new UserResponse.Token(accessToken, refreshToken, time.getTimeMillis() + ACCESS_TOKEN_VALID_TIME);
 	}
 
-	private String generateJwt(Long userId, Date expireIn) {
+	private String generateAccessToken(Long userId, TimeValue time) {
+		Date accessTokenExpireIn = time.expireIn(ACCESS_TOKEN_VALID_TIME);
 		return Jwts.builder()
 			.claim(jwtSecretProvider.getSignature(), userId)
-			.expiration(expireIn)
+			.expiration(accessTokenExpireIn)
 			.signWith(jwtSecretProvider.getSecretKey())
 			.compact();
+	}
+
+	private String generateRefreshToken(Long userId, TimeValue time) {
+		Date refreshTokenExpireIn = time.expireIn(REFRESH_TOKEN_VALID_TIME);
+
+		String refreshToken = Jwts.builder()
+			.claim(jwtSecretProvider.getSignature(), userId)
+			.claim(jwtSecretProvider.getExpireKey(), refreshTokenExpireIn)
+			.expiration(refreshTokenExpireIn)
+			.signWith(jwtSecretProvider.getSecretKey())
+			.compact();
+
+		cacheUtil.saveRefreshToken(jwtSecretProvider.cacheKey(userId), refreshToken, REFRESH_TOKEN_VALID_TIME);
+		return refreshToken;
+	}
+
+	private boolean shouldReissue(String oldRefreshToken, TimeValue time) {
+		Date expireIn = parser.parseExpireIn(oldRefreshToken);
+		return time.isWithinThreeDays(expireIn);
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtGenerator.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtGenerator.java
@@ -58,7 +58,7 @@ public class JwtGenerator {
 
 		String refreshToken = Jwts.builder()
 			.claim(jwtSecretProvider.getSignature(), userId)
-			.claim(jwtSecretProvider.getExpireKey(), refreshTokenExpireIn)
+			.claim(jwtSecretProvider.getDateKey(), refreshTokenExpireIn)
 			.expiration(refreshTokenExpireIn)
 			.signWith(jwtSecretProvider.getSecretKey())
 			.compact();

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtParser.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtParser.java
@@ -2,7 +2,7 @@ package com.newbarams.ajaja.global.security.jwt.util;
 
 import static com.newbarams.ajaja.global.exception.ErrorCode.*;
 
-import java.util.Optional;
+import java.util.Date;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -12,25 +12,14 @@ import org.springframework.stereotype.Component;
 import com.newbarams.ajaja.global.exception.AjajaException;
 import com.newbarams.ajaja.global.security.common.CustomUserDetailService;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
-import io.jsonwebtoken.security.SecurityException;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class JwtParser {
 	private final CustomUserDetailService userDetailService;
 	private final JwtSecretProvider jwtSecretProvider;
-	private final io.jsonwebtoken.JwtParser parser;
-
-	JwtParser(JwtSecretProvider jwtSecretProvider, CustomUserDetailService userDetailService) {
-		this.jwtSecretProvider = jwtSecretProvider;
-		this.userDetailService = userDetailService;
-		this.parser = Jwts.parser().verifyWith(jwtSecretProvider.getSecretKey()).build();
-	}
+	private final RawParser rawParser;
 
 	public Authentication parseAuthentication(String jwt) {
 		Long userId = parseId(jwt);
@@ -39,57 +28,20 @@ public class JwtParser {
 	}
 
 	public Long parseId(String jwt) {
-		Claims claims = parseClaim(jwt).orElseThrow(() -> new AjajaException(INVALID_TOKEN));
-		return claims.get(jwtSecretProvider.getSignature(), Long.class);
+		return getSpecificClaim(jwt, jwtSecretProvider.getSignature(), Long.class);
 	}
 
 	boolean canParse(String jwt) {
-		try {
-			parser.parseSignedClaims(jwt);
-			return true;
-		} catch (JwtException | IllegalArgumentException e) {
-			return false;
-		}
+		return rawParser.parsable(jwt);
 	}
 
-	private Optional<Claims> parseClaim(String jwt) {
-		try {
-			return Optional.ofNullable(parser.parseSignedClaims(jwt).getPayload());
-		} catch (JwtException | IllegalArgumentException e) {
-			handleParseException(e);
-		}
-
-		return Optional.empty();
+	Date parseExpireIn(String refreshToken) {
+		return getSpecificClaim(refreshToken, jwtSecretProvider.getExpireKey(), Date.class);
 	}
 
-	private void handleParseException(RuntimeException exception) {
-		handleBadSignature(exception);
-		handleExpiredToken(exception);
-		handleUnsupportedToken(exception);
-		handleEmptyClaim(exception);
-	}
-
-	private void handleBadSignature(RuntimeException exception) {
-		if (exception instanceof SecurityException || exception instanceof MalformedJwtException) {
-			throw new AjajaException(INVALID_SIGNATURE);
-		}
-	}
-
-	private void handleExpiredToken(RuntimeException exception) {
-		if (exception instanceof ExpiredJwtException) {
-			throw new AjajaException(EXPIRED_TOKEN);
-		}
-	}
-
-	private void handleUnsupportedToken(RuntimeException exception) {
-		if (exception instanceof UnsupportedJwtException) {
-			throw new AjajaException(UNSUPPORTED_TOKEN);
-		}
-	}
-
-	private void handleEmptyClaim(RuntimeException exception) {
-		if (exception instanceof IllegalArgumentException) {
-			throw new AjajaException(EMPTY_TOKEN);
-		}
+	private <T> T getSpecificClaim(String token, String key, Class<T> type) {
+		return rawParser.parseClaim(token)
+			.map(claims -> claims.get(key, type))
+			.orElseThrow(() -> new AjajaException(INVALID_TOKEN));
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtParser.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtParser.java
@@ -31,12 +31,12 @@ public class JwtParser {
 		return getSpecificClaim(jwt, jwtSecretProvider.getSignature(), Long.class);
 	}
 
-	boolean canParse(String jwt) {
-		return rawParser.parsable(jwt);
+	boolean isParsable(String jwt) {
+		return rawParser.isParsable(jwt);
 	}
 
 	Date parseExpireIn(String refreshToken) {
-		return getSpecificClaim(refreshToken, jwtSecretProvider.getExpireKey(), Date.class);
+		return getSpecificClaim(refreshToken, jwtSecretProvider.getDateKey(), Date.class);
 	}
 
 	private <T> T getSpecificClaim(String token, String key, Class<T> type) {

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtSecretProvider.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtSecretProvider.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 @Getter
 @Component
 class JwtSecretProvider {
-	private static final String DATE_CLAIM_KEY = " DATE";
+	private static final String DATE_CLAIM_POSTFIX = " DATE";
 
 	private final SecretKey secretKey;
 	private final String signature;
@@ -30,7 +30,7 @@ class JwtSecretProvider {
 		return signature + userId;
 	}
 
-	public String getExpireKey() {
-		return signature + DATE_CLAIM_KEY;
+	public String getDateKey() {
+		return signature + DATE_CLAIM_POSTFIX;
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtSecretProvider.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtSecretProvider.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 @Getter
 @Component
 class JwtSecretProvider {
+	private static final String DATE_CLAIM_KEY = " DATE";
+
 	private final SecretKey secretKey;
 	private final String signature;
 
@@ -26,5 +28,9 @@ class JwtSecretProvider {
 
 	public String cacheKey(Long userId) {
 		return signature + userId;
+	}
+
+	public String getExpireKey() {
+		return signature + DATE_CLAIM_KEY;
 	}
 }

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtValidator.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/JwtValidator.java
@@ -21,11 +21,11 @@ public class JwtValidator {
 	 * @author hejow
 	 */
 	public Long validateReissuableAndExtractId(String accessToken, String refreshToken) {
-		return isValidAccessToken(accessToken) ? parser.parseId(accessToken) : validateHistory(refreshToken);
+		return isValidToken(accessToken) ? parser.parseId(accessToken) : validateHistory(refreshToken);
 	}
 
-	private boolean isValidAccessToken(String accessToken) {
-		return parser.canParse(accessToken);
+	private boolean isValidToken(String accessToken) {
+		return parser.isParsable(accessToken);
 	}
 
 	private Long validateHistory(String refreshToken) {

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/RawParser.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/RawParser.java
@@ -1,0 +1,77 @@
+package com.newbarams.ajaja.global.security.jwt.util;
+
+import static com.newbarams.ajaja.global.exception.ErrorCode.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.newbarams.ajaja.global.exception.AjajaException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
+
+@Component
+class RawParser {
+	private final JwtParser parser;
+
+	RawParser(JwtSecretProvider jwtSecretProvider) {
+		this.parser = Jwts.parser().verifyWith(jwtSecretProvider.getSecretKey()).build();
+	}
+
+	boolean parsable(String jwt) {
+		try {
+			parser.parseSignedClaims(jwt);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	Optional<Claims> parseClaim(String jwt) {
+		try {
+			return Optional.ofNullable(parser.parseSignedClaims(jwt).getPayload());
+		} catch (JwtException | IllegalArgumentException e) {
+			handleParseException(e);
+		}
+
+		return Optional.empty();
+	}
+
+	private void handleParseException(RuntimeException exception) {
+		handleBadSignature(exception);
+		handleExpiredToken(exception);
+		handleUnsupportedToken(exception);
+		handleEmptyClaim(exception);
+	}
+
+	private void handleBadSignature(RuntimeException exception) {
+		if (exception instanceof SecurityException || exception instanceof MalformedJwtException) {
+			throw new AjajaException(INVALID_SIGNATURE);
+		}
+	}
+
+	private void handleExpiredToken(RuntimeException exception) {
+		if (exception instanceof ExpiredJwtException) {
+			throw new AjajaException(EXPIRED_TOKEN);
+		}
+	}
+
+	private void handleUnsupportedToken(RuntimeException exception) {
+		if (exception instanceof UnsupportedJwtException) {
+			throw new AjajaException(UNSUPPORTED_TOKEN);
+		}
+	}
+
+	private void handleEmptyClaim(RuntimeException exception) {
+		if (exception instanceof IllegalArgumentException) {
+			throw new AjajaException(EMPTY_TOKEN);
+		}
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/RawParser.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/RawParser.java
@@ -22,10 +22,12 @@ class RawParser {
 	private final JwtParser parser;
 
 	RawParser(JwtSecretProvider jwtSecretProvider) {
-		this.parser = Jwts.parser().verifyWith(jwtSecretProvider.getSecretKey()).build();
+		this.parser = Jwts.parser()
+			.verifyWith(jwtSecretProvider.getSecretKey())
+			.build();
 	}
 
-	boolean parsable(String jwt) {
+	boolean isParsable(String jwt) {
 		try {
 			parser.parseSignedClaims(jwt);
 			return true;

--- a/src/main/java/com/newbarams/ajaja/module/user/application/service/LoginService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/service/LoginService.java
@@ -27,7 +27,7 @@ class LoginService implements LoginUseCase {
 		AccessToken accessToken = authorizeService.authorize(authorizationCode, redirectUri);
 		Profile profile = getProfileService.getProfile(accessToken.getContent());
 		User user = findUserOrCreateIfNotExists(profile.getEmail(), profile.getOauthId());
-		return jwtGenerator.generate(user.getId());
+		return jwtGenerator.login(user.getId());
 	}
 
 	private User findUserOrCreateIfNotExists(String email, Long oauthId) {

--- a/src/main/java/com/newbarams/ajaja/module/user/application/service/ReissueTokenService.java
+++ b/src/main/java/com/newbarams/ajaja/module/user/application/service/ReissueTokenService.java
@@ -18,6 +18,6 @@ class ReissueTokenService implements ReissueTokenUseCase {
 	@Override
 	public UserResponse.Token reissue(String accessToken, String refreshToken) {
 		Long userId = jwtValidator.validateReissuableAndExtractId(accessToken, refreshToken);
-		return jwtGenerator.generate(userId);
+		return jwtGenerator.reissue(userId, refreshToken);
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/global/common/TimeValueTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/common/TimeValueTest.java
@@ -1,0 +1,33 @@
+package com.newbarams.ajaja.global.common;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+class TimeValueTest {
+	@Test
+	void isWithinThreeDays_Success() {
+		// given
+		Date threeDaysBefore = new Date(new Date().getTime() - 60 * 60 * 24 * 3 * 1000L);
+
+		// when
+		boolean withinThreeDays = new TimeValue().isWithinThreeDays(threeDaysBefore);
+
+		// then
+		assertThat(withinThreeDays).isTrue();
+	}
+
+	@Test
+	void isWithinThreeDays_Fail() {
+		// given
+		Date fourDaysBefore = new Date(new Date().getTime() - 60 * 60 * 24 * 4 * 1000L);
+
+		// when
+		boolean withinThreeDays = new TimeValue().isWithinThreeDays(fourDaysBefore);
+
+		// then
+		assertThat(withinThreeDays).isFalse();
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtGeneratorTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtGeneratorTest.java
@@ -1,37 +1,54 @@
 package com.newbarams.ajaja.global.security.jwt.util;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import com.newbarams.ajaja.common.annotation.RedisBasedTest;
-import com.newbarams.ajaja.common.support.MonkeySupport;
+import com.newbarams.ajaja.common.support.MockTestSupport;
 import com.newbarams.ajaja.module.user.dto.UserResponse;
 
 @RedisBasedTest
-class JwtGeneratorTest extends MonkeySupport {
+class JwtGeneratorTest extends MockTestSupport {
 	@Autowired
 	private JwtGenerator jwtGenerator;
-
+	@Autowired
+	private JwtSecretProvider jwtSecretProvider;
 	@Autowired
 	private RedisTemplate<String, Object> redisTemplate;
 
-	@Autowired
-	private JwtSecretProvider jwtSecretProvider;
+	@SpyBean
+	private JwtParser jwtParser;
+
+	private Long userId;
+
+	@BeforeEach
+	void setup() {
+		userId = sut.giveMeOne(Long.class);
+	}
+
+	@AfterEach
+	void clean() {
+		redisTemplate.delete(jwtSecretProvider.getSignature() + userId);
+	}
 
 	@Test
-	@DisplayName("JWT를 생성하면 DTO가 생성되면서 Refresh Token이 cache에 저장되어야 한다.")
-	void generate_Success_WithRefreshTokenSavedOnRedis() {
+	@DisplayName("로그인 시 두 종류의 JWT를 생성하고 그 중에서 Refresh Token은 cache에 저장되어야 한다.")
+	void login_Success_WithRefreshTokenSavedOnRedis() {
 		// given
-		Long userId = sut.giveMeOne(Long.class);
 
 		// when
-		UserResponse.Token response = jwtGenerator.generate(userId);
+		UserResponse.Token response = jwtGenerator.login(userId);
 
 		// then
 		assertThat(response.getAccessToken()).isNotNull();
@@ -42,5 +59,49 @@ class JwtGeneratorTest extends MonkeySupport {
 		assertThat(savedToken).isInstanceOf(String.class);
 		assertThat(response.getRefreshToken()).isEqualTo((String)savedToken);
 		assertThat(response.getAccessTokenExpireIn()).isGreaterThan(new Date().getTime());
+	}
+
+	@Test
+	@DisplayName("재발급 시 Refresh Token의 만료일이 3일 이상 남았다면 Access Token만 재발급되어야 한다.")
+	void reissue_Success_WithOnlyAccessTokenGenerated() throws InterruptedException {
+		// given
+		UserResponse.Token logined = jwtGenerator.login(userId);
+		TimeUnit.SECONDS.sleep(1); // to avoid test fail
+
+		// when
+		UserResponse.Token reissued = jwtGenerator.reissue(userId, logined.getRefreshToken());
+
+		// then
+		assertThat(reissued.getAccessToken()).isNotEqualTo(logined.getAccessToken());
+		assertThat(reissued.getRefreshToken()).isEqualTo(logined.getRefreshToken());
+
+		Object savedToken = redisTemplate.opsForValue().get(jwtSecretProvider.getSignature() + userId);
+		assertThat(savedToken).isNotNull();
+		assertThat(savedToken).isInstanceOf(String.class);
+		assertThat(reissued.getRefreshToken()).isEqualTo((String)savedToken);
+	}
+
+	@Test
+	@DisplayName("재발급 시 Refresh Token의 만료일이 3일 이하라면 모두 새롭게 발급되어야 한다.")
+	void reissue_Success_WithNewRefreshToken() throws InterruptedException {
+		// given
+		UserResponse.Token logined = jwtGenerator.login(userId);
+
+		Date now = new Date();
+		Date twoDaysBefore = new Date(now.getTime() - 60 * 60 * 24 * 2 * 1000L);
+		given(jwtParser.parseExpireIn(logined.getRefreshToken())).willReturn(twoDaysBefore);
+		TimeUnit.SECONDS.sleep(1); // to avoid test fail
+
+		// when
+		UserResponse.Token reissued = jwtGenerator.reissue(userId, logined.getRefreshToken());
+
+		// then
+		assertThat(reissued.getAccessToken()).isNotEqualTo(logined.getAccessToken());
+		assertThat(reissued.getRefreshToken()).isNotEqualTo(logined.getRefreshToken());
+
+		Object savedToken = redisTemplate.opsForValue().get(jwtSecretProvider.getSignature() + userId);
+		assertThat(savedToken).isNotNull();
+		assertThat(savedToken).isInstanceOf(String.class);
+		assertThat(reissued.getRefreshToken()).isEqualTo((String)savedToken);
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtParserTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtParserTest.java
@@ -140,11 +140,11 @@ class JwtParserTest extends MonkeySupport {
 	class CanParseTest {
 		@Test
 		@DisplayName("유효한 토큰을 파싱을 시도하면 true를 리턴해야 한다.")
-		void canParse_Success_ByValidToken() {
+		void isParsable_Success_ByValidToken() {
 			// given
 
 			// when
-			boolean shouldBeTrue = jwtParser.canParse(accessToken);
+			boolean shouldBeTrue = jwtParser.isParsable(accessToken);
 
 			// then
 			assertThat(shouldBeTrue).isTrue();
@@ -152,7 +152,7 @@ class JwtParserTest extends MonkeySupport {
 
 		@Test
 		@DisplayName("유효하지 않은 토큰으로 파싱을 시도하면 false를 리턴해야 한다.")
-		void canParse_Fail_ByInvalidToken() {
+		void isParsable_Fail_ByInvalidToken() {
 			// given
 			String invalidToken = """
 				eyJhbGciOiJIUzI1NiJ9.
@@ -161,7 +161,7 @@ class JwtParserTest extends MonkeySupport {
 				""";
 
 			// when
-			boolean shouldBeFalse = jwtParser.canParse(invalidToken);
+			boolean shouldBeFalse = jwtParser.isParsable(invalidToken);
 
 			// then
 			assertThat(shouldBeFalse).isFalse();

--- a/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtRemoverTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtRemoverTest.java
@@ -29,7 +29,7 @@ class JwtRemoverTest extends MonkeySupport {
 	void remove_Success() {
 		// given
 		Long userId = sut.giveMeOne(Long.class);
-		jwtGenerator.generate(userId);
+		jwtGenerator.login(userId);
 
 		// when
 		jwtRemover.remove(userId);

--- a/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtValidatorTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtValidatorTest.java
@@ -32,7 +32,7 @@ class JwtValidatorTest extends MonkeySupport {
 	@BeforeEach
 	void setup() {
 		userId = sut.giveMeOne(Long.class);
-		tokens = jwtGenerator.generate(userId);
+		tokens = jwtGenerator.login(userId);
 	}
 
 	@AfterEach

--- a/src/test/java/com/newbarams/ajaja/module/user/application/service/LoginServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/service/LoginServiceTest.java
@@ -66,7 +66,7 @@ class LoginServiceTest extends MockTestSupport {
 			then(getProfileService).should(times(1)).getProfile(any());
 			then(userRepository).should(times(1)).findByEmail(any());
 			then(userRepository).should(times(1)).save(any());
-			then(jwtGenerator).should(times(1)).generate(any());
+			then(jwtGenerator).should(times(1)).login(any());
 		}
 
 		@Test
@@ -85,7 +85,7 @@ class LoginServiceTest extends MockTestSupport {
 			then(getProfileService).should(times(1)).getProfile(any());
 			then(userRepository).should(times(1)).findByEmail(any());
 			then(userRepository).shouldHaveNoMoreInteractions();
-			then(jwtGenerator).should(times(1)).generate(any());
+			then(jwtGenerator).should(times(1)).login(any());
 		}
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/module/user/application/service/ReissueTokenServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/user/application/service/ReissueTokenServiceTest.java
@@ -24,15 +24,14 @@ class ReissueTokenServiceTest extends MockTestSupport {
 	@Test
 	void reissue_Success_WithExpectedCall() {
 		// given
-		Long userId = sut.giveMeOne(Long.class);
 		UserResponse.Token tokens = sut.giveMeOne(UserResponse.Token.class);
-		given(jwtGenerator.generate(any())).willReturn(tokens);
+		given(jwtGenerator.reissue(any(), anyString())).willReturn(tokens);
 
 		// when
 		UserResponse.Token response = reissueTokenService.reissue(tokens.getAccessToken(), tokens.getRefreshToken());
 
 		// then
-		then(jwtGenerator).should(times(1)).generate(any());
+		then(jwtGenerator).should(times(1)).reissue(any(), anyString());
 		then(jwtValidator).should(times(1)).validateReissuableAndExtractId(any(), anyString());
 		assertThat(response).usingRecursiveComparison().isEqualTo(tokens);
 	}


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 토큰 생성 로직을 수정했습니다.
- `JwtParser`의 책임을 분리했습니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 이제부터 Refresh Token에 유저 정보가 들어갑니다. 따라서 탈취될 상황을 대비해서 **만료 시간이 3일 이내일 경우에만 Refresh Token을 재발급**하도록 수정했습니다. 그로 인해서 생성 로직을 분리했습니다.
- JwtParser가 너무 많은 책임을 가지고 있어서 코드를 보기 어려웠습니다. **라이브러리를 활용한 원시적인 Parsing은 `RawParser`가 담당**하도록 책임을 분리했습니다.
- `TimeValue`에 있던 불필요한 코드를 제거하고 검증 로직을 추가했습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] parseExpireIn_Success_WithinOneWeek
- [x] reissue_Success_WithNewRefreshToken
- [x] reissue_Success_WithOnlyAccessTokenGenerated
- [x] isWithinThreeDays_Success
- [x] isWithinThreeDays_Fail