### PR TITLE
Add(.src) : 리마인드 정보 수정을 위한 별도 API 구현

### DIFF
--- a/src/main/java/com/newbarams/ajaja/module/plan/application/UpdatePlanService.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/application/UpdatePlanService.java
@@ -44,10 +44,6 @@ public class UpdatePlanService {
 			month,
 			request.title(),
 			request.description(),
-			request.remindTotalPeriod(),
-			request.remindTerm(),
-			request.remindDate(),
-			request.remindTime(),
 			request.isPublic(),
 			request.canRemind(),
 			request.canAjaja()

--- a/src/main/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoService.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoService.java
@@ -1,0 +1,28 @@
+package com.newbarams.ajaja.module.plan.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.newbarams.ajaja.global.exception.AjajaException;
+import com.newbarams.ajaja.global.exception.ErrorCode;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.plan.domain.repository.PlanRepository;
+import com.newbarams.ajaja.module.plan.dto.PlanRequest;
+import com.newbarams.ajaja.module.plan.mapper.MessageMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateRemindInfoService {
+	private final PlanRepository planRepository;
+	private final MessageMapper mapper;
+
+	public void updateRemindInfo(Long planId, PlanRequest.UpdateRemind request) {
+		Plan plan = planRepository.findById(planId)
+			.orElseThrow(() -> AjajaException.withId(planId, ErrorCode.NOT_FOUND_PLAN));
+
+		plan.updateRemind(mapper.toDomain(request), mapper.toDomain(request.getMessages()));
+	}
+}

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
@@ -8,6 +8,7 @@ import java.util.List;
 import org.hibernate.annotations.Where;
 
 import com.newbarams.ajaja.global.common.BaseEntity;
+import com.newbarams.ajaja.global.common.TimeValue;
 import com.newbarams.ajaja.global.exception.AjajaException;
 import com.newbarams.ajaja.module.ajaja.domain.Ajaja;
 
@@ -122,10 +123,6 @@ public class Plan extends BaseEntity<Plan> {
 		int month,
 		String title,
 		String description,
-		int remindTotalPeriod,
-		int remindTerm,
-		int remindDate,
-		String remindTime,
 		boolean isPublic,
 		boolean canRemind,
 		boolean canAjaja
@@ -133,9 +130,20 @@ public class Plan extends BaseEntity<Plan> {
 		validateModifiableMonth(month);
 		validateUser(userId);
 		this.content = content.update(title, description);
-		this.info = info.update(remindTotalPeriod, remindTerm, remindDate, remindTime);
 		this.status = status.update(isPublic, canRemind, canAjaja);
 		this.validateSelf();
+	}
+
+	public void updateRemind(
+		RemindInfo info,
+		List<Message> messages
+	) {
+		if (new TimeValue().getMonth() != 12) { // todo : QA를 위해 변경 달을 12월로 지정 , 서비스 시작 전 단위 기간으로 변경
+			throw new AjajaException(INVALID_UPDATABLE_DATE);
+		}
+
+		this.info = info;
+		this.messages = messages;
 	}
 
 	public void updateAchieve(int achieveRate) {

--- a/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/domain/Plan.java
@@ -144,6 +144,7 @@ public class Plan extends BaseEntity<Plan> {
 
 		this.info = info;
 		this.messages = messages;
+		this.validateSelf();
 	}
 
 	public void updateAchieve(int achieveRate) {

--- a/src/main/java/com/newbarams/ajaja/module/plan/dto/PlanRequest.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/dto/PlanRequest.java
@@ -23,12 +23,12 @@ public class PlanRequest {
 
 		List<String> tags,
 
-		List<CreateMessage> messages
+		List<Message> messages
 	) {
 	}
 
 	@Data
-	public static class CreateMessage {
+	public static class Message {
 		private final String content;
 		private final int remindMonth;
 		private final int remindDay;
@@ -38,19 +38,21 @@ public class PlanRequest {
 		String title,
 		String description,
 
-		int remindTotalPeriod,
-		int remindTerm,
-		int remindDate,
-		String remindTime,
-
 		boolean isPublic,
 		boolean canRemind,
 		boolean canAjaja,
 
-		List<String> tags,
-
-		List<String> messages
+		List<String> tags
 	) {
+	}
+
+	@Data
+	public static class UpdateRemind {
+		int remindTotalPeriod;
+		int remindTerm;
+		int remindDate;
+		String remindTime;
+		List<Message> messages;
 	}
 
 	public record GetAll(

--- a/src/main/java/com/newbarams/ajaja/module/plan/mapper/MessageMapper.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/mapper/MessageMapper.java
@@ -6,11 +6,14 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import com.newbarams.ajaja.module.plan.domain.Message;
+import com.newbarams.ajaja.module.plan.domain.RemindInfo;
 import com.newbarams.ajaja.module.plan.dto.PlanRequest;
 
 @Mapper(componentModel = "spring")
 public interface MessageMapper {
 	@Mapping(source = "dto.remindMonth", target = "remindMonth")
 	@Mapping(source = "dto.remindDay", target = "remindDay")
-	List<Message> toDomain(List<PlanRequest.CreateMessage> dto);
+	List<Message> toDomain(List<PlanRequest.Message> dto);
+
+	RemindInfo toDomain(PlanRequest.UpdateRemind dto);
 }

--- a/src/main/java/com/newbarams/ajaja/module/plan/mapper/PlanMapper.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/mapper/PlanMapper.java
@@ -43,7 +43,7 @@ public class PlanMapper {
 		return new RemindInfo(remindTotalPeriod, remindTerm, remindDate, remindTime);
 	}
 
-	public static List<Message> toMessages(List<PlanRequest.CreateMessage> messageList) {
+	public static List<Message> toMessages(List<PlanRequest.Message> messageList) {
 		MessageMapper mapper = Mappers.getMapper(MessageMapper.class);
 
 		if (messageList == null) {

--- a/src/main/java/com/newbarams/ajaja/module/plan/presentation/PlanController.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/presentation/PlanController.java
@@ -4,6 +4,7 @@ import static org.springframework.http.HttpStatus.*;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +27,7 @@ import com.newbarams.ajaja.module.plan.application.GetPlanAchieveService;
 import com.newbarams.ajaja.module.plan.application.LoadPlanInfoService;
 import com.newbarams.ajaja.module.plan.application.LoadPlanService;
 import com.newbarams.ajaja.module.plan.application.UpdatePlanService;
+import com.newbarams.ajaja.module.plan.application.UpdateRemindInfoService;
 import com.newbarams.ajaja.module.plan.dto.PlanInfoResponse;
 import com.newbarams.ajaja.module.plan.dto.PlanRequest;
 import com.newbarams.ajaja.module.plan.dto.PlanResponse;
@@ -51,6 +53,7 @@ public class PlanController {
 	private final GetPlanAchieveService getPlanAchieveService;
 	private final UpdatePlanService updatePlanService;
 	private final LoadPlanInfoService loadPlanInfoService;
+	private final UpdateRemindInfoService updateRemindInfoService;
 
 	@Operation(summary = "[토큰 필요] 계획 생성 API")
 	@PostMapping
@@ -164,5 +167,27 @@ public class PlanController {
 		List<PlanResponse.GetAll> responses = getPlanService.loadAllPlans(request);
 
 		return new AjajaResponse<>(true, responses);
+	}
+
+	@Operation(summary = "[토큰 필요] 리마인드 정보 수정 API", description = "<b>url에 플랜id 값이 필요합니다.</b>",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "성공적으로 리마인드 정보를 수정하였습니다."),
+			@ApiResponse(responseCode = "400", description = "유효하지 않은 토큰입니다.",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(responseCode = "400", description = "변경 가능한 기간이 아닙니다.",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(responseCode = "404", description = "계획 정보를 불러오지 못했습니다.",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(responseCode = "500", description = "서버 내부 문제입니다. 관리자에게 문의 바랍니다.",
+				content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+		})
+	@PutMapping("/{planId}/reminds")
+	@ResponseStatus(HttpStatus.OK)
+	public AjajaResponse<Void> modifyRemindInfo(
+		@PathVariable Long planId,
+		@RequestBody PlanRequest.UpdateRemind request
+	) {
+		updateRemindInfoService.updateRemindInfo(planId, request);
+		return AjajaResponse.ok();
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/common/support/WebMvcTestSupport.java
+++ b/src/test/java/com/newbarams/ajaja/common/support/WebMvcTestSupport.java
@@ -22,6 +22,7 @@ import com.newbarams.ajaja.module.plan.application.GetPlanAchieveService;
 import com.newbarams.ajaja.module.plan.application.LoadPlanInfoService;
 import com.newbarams.ajaja.module.plan.application.LoadPlanService;
 import com.newbarams.ajaja.module.plan.application.UpdatePlanService;
+import com.newbarams.ajaja.module.plan.application.UpdateRemindInfoService;
 import com.newbarams.ajaja.module.remind.application.LoadRemindInfoService;
 import com.newbarams.ajaja.module.user.application.service.UserMockBeans;
 import com.newbarams.ajaja.module.user.domain.UserQueryRepository;
@@ -65,6 +66,8 @@ public abstract class WebMvcTestSupport extends MonkeySupport {
 	protected UpdatePlanService updatePlanService;
 	@MockBean
 	protected LoadPlanInfoService loadPlanInfoService;
+	@MockBean
+	protected UpdateRemindInfoService updateRemindInfoService;
 
 	// Feedback
 	@MockBean

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/UpdatePlanServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/UpdatePlanServiceTest.java
@@ -53,8 +53,8 @@ class UpdatePlanServiceTest {
 			.messages(List.of(new Message("content", 3, 15)))
 			.build();
 
-		PlanRequest.Update request = new PlanRequest.Update("title", "des", 12, 1,
-			15, "MORNING", true, true, true, null, List.of("message"));
+		PlanRequest.Update request
+			= new PlanRequest.Update("title", "des", true, true, true, null);
 
 		Plan saved = planRepository.save(plan);
 
@@ -68,8 +68,8 @@ class UpdatePlanServiceTest {
 	void updatePlan_Fail_By_Not_Found_Plan() {
 		Long planId = Arbitraries.longs().lessOrEqual(-1L).sample();
 
-		PlanRequest.Update request = new PlanRequest.Update("title", "des", 12, 1,
-			15, "MORNING", true, true, true, null, List.of("message"));
+		PlanRequest.Update request
+			= new PlanRequest.Update("title", "des", true, true, true, null);
 
 		assertThatThrownBy(() -> updatePlanService.update(planId, 1L, request, 1))
 			.isInstanceOf(AjajaException.class);
@@ -87,8 +87,8 @@ class UpdatePlanServiceTest {
 			.messages(List.of(new Message("content", 3, 15)))
 			.build();
 
-		PlanRequest.Update request = new PlanRequest.Update("title", "des", 12, 1,
-			15, "MORNING", true, true, true, null, List.of("message"));
+		PlanRequest.Update request
+			= new PlanRequest.Update("title", "des", true, true, true, null);
 
 		Plan saved = planRepository.save(plan);
 

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoServiceTest.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -42,6 +43,7 @@ class UpdateRemindInfoServiceTest extends MockTestSupport {
 	}
 
 	@Test
+	@DisplayName("플랜의 리마인드 정보와 메세지를 수정한다.")
 	void updateRemindInfo_Success_WithNNoException() {
 		// given
 		Long planId = 1L;
@@ -56,7 +58,21 @@ class UpdateRemindInfoServiceTest extends MockTestSupport {
 	}
 
 	@Test
+	@DisplayName("조회된 정보가 없을 시에 예외를 던진다.")
 	void updateRemindInfo_Fail_ByNotFoundPlan() {
+		// given
+		Long planId = 2L;
+		given(repository.findById(anyLong())).willReturn(Optional.empty());
+
+		// when,then
+		Assertions.assertThatException().isThrownBy(
+			() -> updateRemindInfoService.updateRemindInfo(planId, dto)
+		);
+	}
+
+	@Test
+	@DisplayName("변경 기간이 아니면 예외를 던진다.")
+	void updateRemindInfo_Fail_ByInvalidUpdatableDate() {
 		// given
 		Long planId = 1L;
 		given(repository.findById(anyLong())).willReturn(Optional.of(mockPlan));

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoServiceTest.java
@@ -24,6 +24,7 @@ import com.newbarams.ajaja.module.plan.mapper.MessageMapper;
 class UpdateRemindInfoServiceTest extends MockTestSupport {
 	@InjectMocks
 	private UpdateRemindInfoService updateRemindInfoService;
+
 	@Mock
 	private PlanRepository repository;
 	@Mock
@@ -76,9 +77,7 @@ class UpdateRemindInfoServiceTest extends MockTestSupport {
 		// given
 		Long planId = 1L;
 		given(repository.findById(anyLong())).willReturn(Optional.of(mockPlan));
-		given(mapper.toDomain(dto.getMessages())).willReturn(messages);
-		given(mapper.toDomain(dto)).willReturn(info);
-		doThrow(AjajaException.class).when(mockPlan).updateRemind(info, messages);
+		doThrow(AjajaException.class).when(mockPlan).updateRemind(any(), any());
 
 		// when,then
 		Assertions.assertThatException().isThrownBy(

--- a/src/test/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoServiceTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/application/UpdateRemindInfoServiceTest.java
@@ -1,0 +1,72 @@
+package com.newbarams.ajaja.module.plan.application;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.newbarams.ajaja.common.support.MockTestSupport;
+import com.newbarams.ajaja.global.exception.AjajaException;
+import com.newbarams.ajaja.module.plan.domain.Message;
+import com.newbarams.ajaja.module.plan.domain.Plan;
+import com.newbarams.ajaja.module.plan.domain.RemindInfo;
+import com.newbarams.ajaja.module.plan.domain.repository.PlanRepository;
+import com.newbarams.ajaja.module.plan.dto.PlanRequest;
+import com.newbarams.ajaja.module.plan.mapper.MessageMapper;
+
+class UpdateRemindInfoServiceTest extends MockTestSupport {
+	@InjectMocks
+	private UpdateRemindInfoService updateRemindInfoService;
+	@Mock
+	private PlanRepository repository;
+	@Mock
+	private MessageMapper mapper;
+	@Mock
+	private Plan mockPlan;
+
+	private Plan plan;
+	private PlanRequest.UpdateRemind dto;
+	private List<Message> messages;
+	private RemindInfo info;
+
+	@BeforeEach
+	void setUp() {
+		plan = sut.giveMeOne(Plan.class);
+		dto = sut.giveMeOne(PlanRequest.UpdateRemind.class);
+	}
+
+	@Test
+	void updateRemindInfo_Success_WithNNoException() {
+		// given
+		Long planId = 1L;
+		given(repository.findById(anyLong())).willReturn(Optional.of(plan));
+		given(mapper.toDomain(dto.getMessages())).willReturn(messages);
+		given(mapper.toDomain(dto)).willReturn(info);
+
+		// when,then
+		Assertions.assertThatNoException().isThrownBy(
+			() -> updateRemindInfoService.updateRemindInfo(planId, dto)
+		);
+	}
+
+	@Test
+	void updateRemindInfo_Fail_ByNotFoundPlan() {
+		// given
+		Long planId = 1L;
+		given(repository.findById(anyLong())).willReturn(Optional.of(mockPlan));
+		given(mapper.toDomain(dto.getMessages())).willReturn(messages);
+		given(mapper.toDomain(dto)).willReturn(info);
+		doThrow(AjajaException.class).when(mockPlan).updateRemind(info, messages);
+
+		// when,then
+		Assertions.assertThatException().isThrownBy(
+			() -> updateRemindInfoService.updateRemindInfo(planId, dto)
+		);
+	}
+}

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/PlanTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/PlanTest.java
@@ -90,8 +90,7 @@ class PlanTest {
 		Plan plan = fixtureMonkey.giveMeOne(Plan.class);
 
 		assertThatNoException().isThrownBy(() ->
-			plan.update(plan.getUserId(), 1, "title", "des", 12, 3, 1,
-				"EVENING", true, true, true)
+			plan.update(plan.getUserId(), 1, "title", "des", true, true, true)
 		);
 	}
 
@@ -101,8 +100,8 @@ class PlanTest {
 		Plan plan = fixtureMonkey.giveMeOne(Plan.class);
 		List<Message> messages = fixtureMonkey.giveMe(Message.class, 3);
 
-		assertThatThrownBy(() -> plan.update(plan.getUserId(), 12, "title", "des", 12, 3,
-			1, "EVENING", true, true, true))
+		assertThatThrownBy(() ->
+			plan.update(plan.getUserId(), 12, "title", "des", true, true, true))
 			.isInstanceOf(AjajaException.class)
 			.hasMessage(INVALID_UPDATABLE_DATE.getMessage());
 	}
@@ -113,11 +112,9 @@ class PlanTest {
 		Plan plan = fixtureMonkey.giveMeOne(Plan.class);
 		List<Message> messages = fixtureMonkey.giveMe(Message.class, 3);
 
-		plan.update(plan.getUserId(), 1, "title", "des", 12, 3, 1,
-			"EVENING", true, false, true);
+		plan.update(plan.getUserId(), 1, "title", "des", true, false, true);
 
 		assertThat(plan.getContent().getTitle()).isEqualTo("title");
-		assertThat(plan.getInfo().getRemindDate()).isEqualTo(1);
 		assertThat(plan.getStatus().isCanRemind()).isEqualTo(false);
 	}
 }


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- API 요구 사항이 변경 됨에 따라, 리마인드 정보 수정을 위한 별도 API를 구현하였습니다.
![image](https://github.com/New-Barams/This-Year-Ajaja-BE/assets/102570281/ed51da50-96a7-4705-8329-b860fb70cf26)


<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- RemindInfo 도메인으로 변경하는 행위는 PlanMapper에 있는 게 더 자연스럽다 생각하지만, 예슬님이 작업 중이신 PlanMapper 와의 충돌을 고려하여 지금은 MessageMapper에 위치시켰습니다.

# ✅ 작성한 테스트
- [x] updateRemindInfo_Success_WithNNoException
- [x] updateRemindInfo_Fail_ByNotFoundPlan
- [x] updateRemindInfo_Fail_ByInvalidUpdatableDate