### PR TITLE
Fix(.plan): casting bigint DB reserved word error

### DIFF
--- a/src/main/java/com/newbarams/ajaja/global/security/jwt/util/RawParser.java
+++ b/src/main/java/com/newbarams/ajaja/global/security/jwt/util/RawParser.java
@@ -48,14 +48,21 @@ class RawParser {
 
 	private void handleParseException(RuntimeException exception) {
 		handleBadSignature(exception);
+		handleInvalidStructure(exception);
 		handleExpiredToken(exception);
 		handleUnsupportedToken(exception);
 		handleEmptyClaim(exception);
 	}
 
 	private void handleBadSignature(RuntimeException exception) {
-		if (exception instanceof SecurityException || exception instanceof MalformedJwtException) {
+		if (exception instanceof SecurityException) {
 			throw new AjajaException(INVALID_SIGNATURE);
+		}
+	}
+
+	private void handleInvalidStructure(RuntimeException exception) {
+		if (exception instanceof MalformedJwtException) {
+			throw new AjajaException(INVALID_TOKEN);
 		}
 	}
 

--- a/src/main/java/com/newbarams/ajaja/module/plan/infra/PlanQueryRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/infra/PlanQueryRepository.java
@@ -31,7 +31,6 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -71,9 +70,9 @@ public class PlanQueryRepository {
 		return Optional.ofNullable(queryFactory.select(new QPlanResponse_Detail(
 				new QPlanResponse_Writer(
 					userEntity.nickname,
-					userId == null ? FALSE : userEntity.id.eq(userId),
+					userId == null ? FALSE : userEntity.id.intValue().eq(asNumber(userId)), // querydsl bigint casting error
 					userId == null ? FALSE : isAjajaPressed(userId, id)),
-				Expressions.asNumber(id),
+				asNumber(id),
 				planEntity.title,
 				planEntity.description,
 				planEntity.iconNumber,
@@ -81,7 +80,7 @@ public class PlanQueryRepository {
 				planEntity.canRemind,
 				planEntity.canAjaja,
 				planEntity.ajajas.size().longValue(),
-				Expressions.constant(findAllTagsByPlanId(id)),
+				constant(findAllTagsByPlanId(id)),
 				planEntity.createdAt))
 			.from(planEntity)
 			.leftJoin(userEntity).on(userEntity.id.eq(planEntity.userId))
@@ -91,7 +90,7 @@ public class PlanQueryRepository {
 	}
 
 	private BooleanExpression isAjajaPressed(Long userId, Long id) {
-		return Expressions.asBoolean(queryFactory.selectFrom(ajaja)
+		return asBoolean(queryFactory.selectFrom(ajaja)
 			.where(ajaja.targetId.eq(id)
 				.and(ajaja.userId.eq(userId))
 				.and(ajaja.type.eq(Ajaja.Type.PLAN))

--- a/src/main/java/com/newbarams/ajaja/module/plan/infra/PlanQueryRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/infra/PlanQueryRepository.java
@@ -70,7 +70,7 @@ public class PlanQueryRepository {
 		return Optional.ofNullable(queryFactory.select(new QPlanResponse_Detail(
 				new QPlanResponse_Writer(
 					userEntity.nickname,
-					userId == null ? FALSE : userEntity.id.intValue().eq(asNumber(userId)), // querydsl bigint casting error
+					userId == null ? FALSE : userEntity.id.intValue().eq(asNumber(userId)), // bigint casting error
 					userId == null ? FALSE : isAjajaPressed(userId, id)),
 				asNumber(id),
 				planEntity.title,

--- a/src/main/java/com/newbarams/ajaja/module/plan/presentation/PlanController.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/presentation/PlanController.java
@@ -23,6 +23,7 @@ import com.newbarams.ajaja.global.common.AjajaResponse;
 import com.newbarams.ajaja.global.exception.ErrorResponse;
 import com.newbarams.ajaja.global.security.common.UserId;
 import com.newbarams.ajaja.global.security.jwt.util.JwtParser;
+import com.newbarams.ajaja.global.util.BearerUtils;
 import com.newbarams.ajaja.module.ajaja.application.SwitchAjajaService;
 import com.newbarams.ajaja.module.plan.application.CreatePlanService;
 import com.newbarams.ajaja.module.plan.application.DeletePlanService;
@@ -72,9 +73,14 @@ public class PlanController {
 		@RequestHeader(value = AUTHORIZATION, required = false) String accessToken,
 		@PathVariable Long id
 	) {
-		Long userId = accessToken == null ? null : jwtParser.parseId(accessToken);
+		Long userId = accessToken == null ? null : parseUserId(accessToken);
 		PlanResponse.Detail response = getPlanService.loadByIdAndOptionalUser(userId, id);
 		return AjajaResponse.ok(response);
+	}
+
+	private Long parseUserId(String accessToken) {
+		BearerUtils.validate(accessToken);
+		return jwtParser.parseId(BearerUtils.resolve(accessToken));
 	}
 
 	@Operation(summary = "[토큰 필요] 계획 생성 API")

--- a/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtParserTest.java
+++ b/src/test/java/com/newbarams/ajaja/global/security/jwt/util/JwtParserTest.java
@@ -110,15 +110,13 @@ class JwtParserTest extends MonkeySupport {
 	void parseId_Fail_ByWrongSignature() {
 		// given
 		String wrongSignatureToken = """
-			eyJhbGciOiJIUzI1NiJ9.
-			eyJuYW1lIjoiSGVqb3cifQ.
-			SI7XBRHE_95nkxQ69SiiCQcqDkZ-FW1RdxNL1DmAAAg
+			eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.
+			eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.
+			SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
 			""";
 
 		// when, then
-		assertThatException()
-			.isThrownBy(() -> jwtParser.parseId(wrongSignatureToken))
-			.withMessage(INVALID_SIGNATURE.getMessage());
+		assertThatException().isThrownBy(() -> jwtParser.parseId(wrongSignatureToken));
 	}
 
 	@Test

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -73,47 +74,73 @@ class PlanQueryRepositoryTest {
 			.sample();
 	}
 
-	@Test
-	@DisplayName("사용자 ID를 입력하지 않고 상세 조회하면 작성자 정보에서 작성자 여부와 좋아요 여부는 false가 되어야 한다.")
-	void findPlanDetailByIdAndOptionalUser_Success_WithUserIdNotEntered() {
-		// given
-		Plan save = planRepository.save(plan);
+	@Nested
+	@DisplayName("findPlanDetailByIdAndOptionalUser 테스트")
+	class FindPlanDetailByIdAndOptionalUserTest {
+		@Test
+		@DisplayName("사용자 ID를 입력하지 않고 상세 조회하면 작성자 정보에서 작성자 여부와 좋아요 여부는 false가 되어야 한다.")
+		void findPlanDetailByIdAndOptionalUser_Success_WithUserIdNotEntered() { // no ajaja pressed query
+			// given
+			Plan save = planRepository.save(plan);
 
-		// when
-		Optional<PlanResponse.Detail> result =
-			planQueryRepository.findPlanDetailByIdAndOptionalUser(null, save.getId());
+			// when
+			Optional<PlanResponse.Detail> result =
+				planQueryRepository.findPlanDetailByIdAndOptionalUser(null, save.getId());
 
-		// then
-		assertThat(result).isNotEmpty();
+			// then
+			assertThat(result).isNotEmpty();
 
-		PlanResponse.Detail detail = result.get();
-		assertThat(detail.getWriter().getNickname()).isEqualTo(user.getNickname().getNickname());
-		assertThat(detail.getWriter().isOwner()).isFalse();
-		assertThat(detail.getWriter().isAjajaPressed()).isFalse();
-		assertThat(detail.getId()).isEqualTo(save.getId());
-		assertThat(detail.getAjajas()).isEqualTo(save.getAjajas().size());
-		assertThat(detail.isPublic()).isEqualTo(save.getStatus().isPublic());
-	}
+			PlanResponse.Detail detail = result.get();
+			assertThat(detail.getWriter().getNickname()).isEqualTo(user.getNickname().getNickname());
+			assertThat(detail.getWriter().isOwner()).isFalse();
+			assertThat(detail.getWriter().isAjajaPressed()).isFalse();
+			assertThat(detail.getId()).isEqualTo(save.getId());
+			assertThat(detail.getAjajas()).isEqualTo(save.getAjajas().size());
+			assertThat(detail.isPublic()).isEqualTo(save.getStatus().isPublic());
+		}
 
-	@Test
-	@DisplayName("작성자의 ID로 상세 조회하면 작성자 정보에서 작성자 여부는 true가 되어야 한다.")
-	void findPlanDetailByIdAndOptionalUser_Success_WithWriterUserId() {
-		// given
-		Plan save = planRepository.save(plan);
+		@Test
+		@DisplayName("작성자의 ID로 상세 조회하면 작성자 정보에서 작성자 여부는 true가 되어야 한다.")
+		void findPlanDetailByIdAndOptionalUser_Success_WithWriterUserId() {
+			// given
+			Plan save = planRepository.save(plan);
 
-		// when
-		Optional<PlanResponse.Detail> result =
-			planQueryRepository.findPlanDetailByIdAndOptionalUser(user.getId(), save.getId());
+			// when
+			Optional<PlanResponse.Detail> result =
+				planQueryRepository.findPlanDetailByIdAndOptionalUser(user.getId(), save.getId());
 
-		// then
-		assertThat(result).isNotEmpty();
+			// then
+			assertThat(result).isNotEmpty();
 
-		PlanResponse.Detail detail = result.get();
-		assertThat(detail.getWriter().getNickname()).isEqualTo(user.getNickname().getNickname());
-		assertThat(detail.getWriter().isOwner()).isTrue();
-		assertThat(detail.getId()).isEqualTo(save.getId());
-		assertThat(detail.getAjajas()).isEqualTo(save.getAjajas().size());
-		assertThat(detail.isPublic()).isEqualTo(save.getStatus().isPublic());
+			PlanResponse.Detail detail = result.get();
+			assertThat(detail.getWriter().getNickname()).isEqualTo(user.getNickname().getNickname());
+			assertThat(detail.getWriter().isOwner()).isTrue();
+			assertThat(detail.getId()).isEqualTo(save.getId());
+			assertThat(detail.getAjajas()).isEqualTo(save.getAjajas().size());
+			assertThat(detail.isPublic()).isEqualTo(save.getStatus().isPublic());
+		}
+
+		@Test
+		@DisplayName("다른 사람의 id로 상세 조회하면 작성자 정보에서 작성자 여부와 좋아요 여부는 false가 되어야 한다.")
+		void findPlanDetailByIdAndOptionalUser_Success_WithStrangerId() {
+			// given
+			Long strangerId = user.getId() + 1;
+			Plan save = planRepository.save(plan);
+
+			// when
+			Optional<PlanResponse.Detail> result =
+				planQueryRepository.findPlanDetailByIdAndOptionalUser(strangerId, save.getId());
+
+			// then
+			assertThat(result).isNotEmpty();
+
+			PlanResponse.Detail detail = result.get();
+			assertThat(detail.getWriter().isOwner()).isFalse();
+			assertThat(detail.getWriter().isAjajaPressed()).isFalse();
+			assertThat(detail.getId()).isEqualTo(save.getId());
+			assertThat(detail.getAjajas()).isEqualTo(save.getAjajas().size());
+			assertThat(detail.isPublic()).isEqualTo(save.getStatus().isPublic());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- QueryDsl에서 bigint로 캐스팅되면서 발생했던 오류를 수정했습니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 현재 스키마가 `bigint`로 설정되어있어서 사용자의 ID를 비교하는 부분에서 **DB의 예약어와 충돌하는 문제**가 발생했습니다.
- querydsl **entity path를 int형으로 변환한 뒤에 비교해서 쿼리**를 보내도록 수정해서 에러를 해결했습니다.
- 기존에 Malformed 예외를 `INVALID_SIGNATURE`로 처리해서 추적하기 어려워서 예외 처리를 분리했습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] findPlanDetailByIdAndOptionalUser_Success_WithStrangerId