### PR TITLE
Fix(.src) : 로깅 클래스 경로에 클래스 패스 적용

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,4 +27,4 @@ logging:
   level:
     com.newbarams.ajaja: DEBUG
     org.springframework.core.LocalVariableTableParameterNameDiscoverer: error
-  config: src/main/resources/logger/logback-spring.xml
+  config: classpath:logger/logback-spring.xml


### PR DESCRIPTION
# 🔍 어떤 PR인가요?
- aws 서버에서 로깅 파일을 찾지 못하는 오류가 발생하였습니다.
- 이 문제를 해결하기 위해 로깅 config에 클래스 패스를 적용하였습니다.

![image](https://github.com/New-Barams/This-Year-Ajaja-BE/assets/102570281/282680c9-7cbc-49b2-a7d2-bb9f94677749)
