### PR TITLE
Update: 전체 계획 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/newbarams/ajaja/module/plan/infra/PlanQueryRepository.java
+++ b/src/main/java/com/newbarams/ajaja/module/plan/infra/PlanQueryRepository.java
@@ -121,10 +121,11 @@ public class PlanQueryRepository {
 
 	public List<PlanResponse.GetAll> findAllByCursorAndSorting(PlanRequest.GetAll conditions) {
 		List<Tuple> tuples = queryFactory.select(planEntity, userEntity.nickname)
-			.from(planEntity, userEntity)
+			.from(planEntity)
 
-			.where(planEntity.userId.eq(userEntity.id),
-				planEntity.isPublic.eq(true),
+			.leftJoin(userEntity).on(userEntity.id.eq(planEntity.userId))
+
+			.where(planEntity.isPublic.eq(true),
 				isEqualsYear(conditions.isCurrent()),
 				cursorPagination(conditions))
 

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
@@ -227,7 +227,7 @@ class PlanQueryRepositoryTest extends MonkeySupport {
 		// when
 		user.delete();
 		userRepository.save(userMapper.toEntity(user));
-		
+
 		List<PlanResponse.GetAll> latestRes = planQueryRepository.findAllByCursorAndSorting(latestReq);
 
 		// then

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
@@ -226,10 +226,11 @@ class PlanQueryRepositoryTest extends MonkeySupport {
 
 		// when
 		user.delete();
+		userRepository.save(userMapper.toEntity(user));
+		
 		List<PlanResponse.GetAll> latestRes = planQueryRepository.findAllByCursorAndSorting(latestReq);
 
 		// then
-		assertThat(user.isDeleted()).isTrue();
 		assertThat(latestRes).hasSize(1);
 	}
 }

--- a/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
+++ b/src/test/java/com/newbarams/ajaja/module/plan/domain/repository/PlanQueryRepositoryTest.java
@@ -216,4 +216,20 @@ class PlanQueryRepositoryTest extends MonkeySupport {
 			() -> planQueryRepository.findAllRemindablePlan("MORNING", TimeValue.now())
 		);
 	}
+
+	@Test
+	@DisplayName("계획 전체 조회 시 탈퇴한 회원의 계획도 조회되어야 한다.")
+	void findAllByCursorAndSorting_Success_WithDeletedUser() {
+		// given
+		planRepository.save(plan);
+		PlanRequest.GetAll latestReq = new PlanRequest.GetAll("latest", true, null, null);
+
+		// when
+		user.delete();
+		List<PlanResponse.GetAll> latestRes = planQueryRepository.findAllByCursorAndSorting(latestReq);
+
+		// then
+		assertThat(user.isDeleted()).isTrue();
+		assertThat(latestRes).hasSize(1);
+	}
 }


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 전체 계획 조회 시 탈퇴한 회원의 계획도 조회되도록 수정하였습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] findAllByCursorAndSorting_Success_WithDeletedUser

<!-- 관련 이슈
프론트에서 작성해준 이슈와 연관되는 PR이라면 
주석을 풀고 작성해주세요! --> 

[//]: # (# 🫡 관련 Issue )
