### PR TITLE
Add(.footprint) : 발자취 도메인 객체 추가

### DIFF
--- a/src/main/java/me/ajaja/module/footprint/domain/Ajaja.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Ajaja.java
@@ -2,25 +2,18 @@ package me.ajaja.module.footprint.domain;
 
 import java.beans.ConstructorProperties;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import me.ajaja.global.common.SelfValidating;
 
 @Getter
 public class Ajaja extends SelfValidating<Ajaja> {
 	@NotNull
-	private final Long userId;
+	private final Long id;
 
-	@NotBlank
-	@Size(max = 20)
-	private final String nickName;
-
-	@ConstructorProperties({"userId", "nickName"})
-	public Ajaja(Long userId, String nickName) {
-		this.userId = userId;
-		this.nickName = nickName;
+	@ConstructorProperties("id")
+	public Ajaja(Long id) {
+		this.id = id;
 		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/Ajaja.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Ajaja.java
@@ -4,6 +4,7 @@ import java.beans.ConstructorProperties;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import me.ajaja.global.common.SelfValidating;
 
@@ -13,11 +14,13 @@ public class Ajaja extends SelfValidating<Ajaja> {
 	private final Long userId;
 
 	@NotBlank
+	@Size(max = 20)
 	private final String nickName;
 
-	@ConstructorProperties({"userId", "userName"})
+	@ConstructorProperties({"userId", "nickName"})
 	public Ajaja(Long userId, String nickName) {
 		this.userId = userId;
 		this.nickName = nickName;
+		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/Ajaja.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Ajaja.java
@@ -1,0 +1,23 @@
+package me.ajaja.module.footprint.domain;
+
+import java.beans.ConstructorProperties;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import me.ajaja.global.common.SelfValidating;
+
+@Getter
+public class Ajaja extends SelfValidating<Ajaja> {
+	@NotNull
+	private final Long userId;
+
+	@NotBlank
+	private final String nickName;
+
+	@ConstructorProperties({"userId", "userName"})
+	public Ajaja(Long userId, String nickName) {
+		this.userId = userId;
+		this.nickName = nickName;
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
@@ -23,7 +23,7 @@ public abstract class Footprint {
 
 	private Title title;
 	private Type type;
-	private Visibility visibility;
+	private FootprintStatus footprintStatus;
 
 	private Set<Tag> tags;
 	private List<Ajaja> ajajas;
@@ -33,7 +33,7 @@ public abstract class Footprint {
 		this.writer = footprintParam.getWriter();
 		this.title = footprintParam.getTitle();
 		this.type = footprintParam.getType();
-		this.visibility = footprintParam.getVisibility();
+		this.footprintStatus = footprintParam.getFootprintStatus();
 		this.tags = (tags == null) ? new HashSet<>() : footprintParam.getTags();
 		this.ajajas = (ajajas == null) ? new ArrayList<>() : footprintParam.getAjajas();
 	}

--- a/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
@@ -5,32 +5,20 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import me.ajaja.module.footprint.dto.FootprintParam;
+import me.ajaja.global.common.SelfValidating;
 
 @Getter
-public abstract class Footprint {
-	public enum Type {
-		FREE, KPT
-	}
-
-	private final Target targetPlan;
+@AllArgsConstructor
+public abstract class Footprint extends SelfValidating<Footprint> {
+	private final Target target;
 	private final Writer writer;
 
 	private Title title;
-	private Type type;
-	private FootprintStatus footprintStatus;
+	private boolean visible;
+	private boolean deleted;
 
-	private Set<Tag> tags;
-	private List<Ajaja> ajajas;
-
-	public Footprint(FootprintParam.Create footprintParam) {
-		this.targetPlan = footprintParam.getTargetPlan();
-		this.writer = footprintParam.getWriter();
-		this.title = footprintParam.getTitle();
-		this.type = footprintParam.getType();
-		this.footprintStatus = footprintParam.getFootprintStatus();
-		this.tags = (tags == null) ? new HashSet<>() : footprintParam.getTags();
-		this.ajajas = (ajajas == null) ? new ArrayList<>() : footprintParam.getAjajas();
-	}
+	private Set<Tag> tags = new HashSet<>();
+	private List<Ajaja> ajajas = new ArrayList<>();
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
@@ -1,0 +1,40 @@
+package me.ajaja.module.footprint.domain;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import lombok.Getter;
+import me.ajaja.module.footprint.dto.FootprintParam;
+
+@Getter
+public abstract class Footprint {
+	public enum Type {
+		FREE, KPT
+	}
+
+	public enum Visibility {
+		PUBLIC, PRIVATE
+	}
+
+	private final TargetPlan targetPlan;
+	private final Writer writer;
+
+	private Title title;
+	private Type type;
+	private Visibility visibility;
+
+	private Set<Tag> tags;
+	private List<Ajaja> ajajas;
+
+	public Footprint(FootprintParam.Create footprintParam) {
+		this.targetPlan = footprintParam.getTargetPlan();
+		this.writer = footprintParam.getWriter();
+		this.title = footprintParam.getTitle();
+		this.type = footprintParam.getType();
+		this.visibility = footprintParam.getVisibility();
+		this.tags = (tags == null) ? new HashSet<>() : footprintParam.getTags();
+		this.ajajas = (ajajas == null) ? new ArrayList<>() : footprintParam.getAjajas();
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
@@ -14,7 +14,7 @@ public abstract class Footprint {
 		FREE, KPT
 	}
 
-	private final TargetPlan targetPlan;
+	private final Target targetPlan;
 	private final Writer writer;
 
 	private Title title;

--- a/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Footprint.java
@@ -14,10 +14,6 @@ public abstract class Footprint {
 		FREE, KPT
 	}
 
-	public enum Visibility {
-		PUBLIC, PRIVATE
-	}
-
 	private final TargetPlan targetPlan;
 	private final Writer writer;
 

--- a/src/main/java/me/ajaja/module/footprint/domain/FootprintFactory.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FootprintFactory.java
@@ -1,0 +1,37 @@
+package me.ajaja.module.footprint.domain;
+
+import java.util.ArrayList;
+
+import me.ajaja.module.footprint.dto.FootprintParam;
+
+public class FootprintFactory {
+	public static FreeFootprint createFreeFootprint(FootprintParam.Create create, String content) {
+		return new FreeFootprint(
+			create.getTarget(),
+			create.getWriter(),
+			create.getTitle(),
+			create.isVisible(),
+			false,
+			create.getTags(),
+			new ArrayList<>(),
+			content
+		);
+	}
+
+	public static KptFootprint createkptFootprint(
+		FootprintParam.Create create, String keepContent, String problemContent, String tryContent
+	) {
+		return new KptFootprint(
+			create.getTarget(),
+			create.getWriter(),
+			create.getTitle(),
+			create.isVisible(),
+			false,
+			create.getTags(),
+			new ArrayList<>(),
+			keepContent,
+			problemContent,
+			tryContent
+		);
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/FootprintStatus.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FootprintStatus.java
@@ -4,19 +4,19 @@ import lombok.Getter;
 
 @Getter
 public class FootprintStatus {
-	private boolean isPublic;
+	private boolean visible;
 	private boolean deleted;
 
-	public FootprintStatus(boolean isPublic) {
-		this.isPublic = isPublic;
+	public FootprintStatus(boolean visible) {
+		this.visible = visible;
 		this.deleted = false;
 	}
 
-	void switchPublic() {
-		this.isPublic = !isPublic;
+	void switchVisibility() {
+		this.visible = !visible;
 	}
 
-	void toDeleted() {
+	void delete() {
 		this.deleted = true;
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/FootprintStatus.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FootprintStatus.java
@@ -1,0 +1,22 @@
+package me.ajaja.module.footprint.domain;
+
+import lombok.Getter;
+
+@Getter
+public class FootprintStatus {
+	private boolean isPublic;
+	private boolean deleted;
+
+	public FootprintStatus(boolean isPublic) {
+		this.isPublic = isPublic;
+		this.deleted = false;
+	}
+
+	void switchPublic() {
+		this.isPublic = !isPublic;
+	}
+
+	void toDeleted() {
+		this.deleted = true;
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
@@ -1,0 +1,16 @@
+package me.ajaja.module.footprint.domain;
+
+import java.sql.Blob;
+
+import lombok.Getter;
+import me.ajaja.module.footprint.dto.FootprintParam;
+
+@Getter
+public class FreeFootprint extends Footprint {
+	private Blob CONTENT;
+
+	public FreeFootprint(FootprintParam.Create footprintParam, Blob CONTENT) {
+		super(footprintParam);
+		this.CONTENT = CONTENT;
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
@@ -7,10 +7,10 @@ import me.ajaja.module.footprint.dto.FootprintParam;
 
 @Getter
 public class FreeFootprint extends Footprint {
-	private Blob CONTENT;
+	private Blob content;
 
-	public FreeFootprint(FootprintParam.Create footprintParam, Blob CONTENT) {
+	public FreeFootprint(FootprintParam.Create footprintParam, Blob content) {
 		super(footprintParam);
-		this.CONTENT = CONTENT;
+		this.content = content;
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
@@ -1,15 +1,13 @@
 package me.ajaja.module.footprint.domain;
 
-import java.sql.Blob;
-
 import lombok.Getter;
 import me.ajaja.module.footprint.dto.FootprintParam;
 
 @Getter
 public class FreeFootprint extends Footprint {
-	private Blob content;
+	private String content;
 
-	public FreeFootprint(FootprintParam.Create footprintParam, Blob content) {
+	public FreeFootprint(FootprintParam.Create footprintParam, String content) {
 		super(footprintParam);
 		this.content = content;
 	}

--- a/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/FreeFootprint.java
@@ -1,14 +1,20 @@
 package me.ajaja.module.footprint.domain;
 
+import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import me.ajaja.module.footprint.dto.FootprintParam;
 
 @Getter
 public class FreeFootprint extends Footprint {
+	@NotBlank
 	private String content;
 
-	public FreeFootprint(FootprintParam.Create footprintParam, String content) {
-		super(footprintParam);
+	FreeFootprint(Target target, Writer writer, Title title, boolean visible, boolean deleted,
+		Set<Tag> tags, List<Ajaja> ajajas, String content) {
+		super(target, writer, title, visible, deleted, tags, ajajas);
 		this.content = content;
+		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
@@ -1,18 +1,26 @@
 package me.ajaja.module.footprint.domain;
 
+import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
-import me.ajaja.module.footprint.dto.FootprintParam;
 
 @Getter
 public class KptFootprint extends Footprint {
+	@NotBlank
 	private String keepContent;
-	private String problem;
+	@NotBlank
+	private String problemContent;
+	@NotBlank
 	private String tryContent;
 
-	public KptFootprint(FootprintParam.Create footprintParam, String keepContent, String problem, String tryContent) {
-		super(footprintParam);
+	KptFootprint(Target target, Writer writer, Title title, boolean visible, boolean deleted, Set<Tag> tags,
+		List<Ajaja> ajajas, String keepContent, String problemContent, String tryContent) {
+		super(target, writer, title, visible, deleted, tags, ajajas);
 		this.keepContent = keepContent;
-		this.problem = problem;
+		this.problemContent = problemContent;
 		this.tryContent = tryContent;
+		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
@@ -1,17 +1,15 @@
 package me.ajaja.module.footprint.domain;
 
-import java.sql.Blob;
-
 import lombok.Getter;
 import me.ajaja.module.footprint.dto.FootprintParam;
 
 @Getter
 public class KptFootprint extends Footprint {
-	private Blob keepContent;
-	private Blob problem;
-	private Blob tryContent;
+	private String keepContent;
+	private String problem;
+	private String tryContent;
 
-	public KptFootprint(FootprintParam.Create footprintParam, Blob keepContent, Blob problem, Blob tryContent) {
+	public KptFootprint(FootprintParam.Create footprintParam, String keepContent, String problem, String tryContent) {
 		super(footprintParam);
 		this.keepContent = keepContent;
 		this.problem = problem;

--- a/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
@@ -1,0 +1,20 @@
+package me.ajaja.module.footprint.domain;
+
+import java.sql.Blob;
+
+import lombok.Getter;
+import me.ajaja.module.footprint.dto.FootprintParam;
+
+@Getter
+public class KptFootprint extends Footprint {
+	private Blob KEEP;
+	private Blob PROBLEM;
+	private Blob TRY;
+
+	public KptFootprint(FootprintParam.Create footprintParam, Blob KEEP, Blob PROBLEM, Blob TRY) {
+		super(footprintParam);
+		this.KEEP = KEEP;
+		this.PROBLEM = PROBLEM;
+		this.TRY = TRY;
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/KptFootprint.java
@@ -7,14 +7,14 @@ import me.ajaja.module.footprint.dto.FootprintParam;
 
 @Getter
 public class KptFootprint extends Footprint {
-	private Blob KEEP;
-	private Blob PROBLEM;
-	private Blob TRY;
+	private Blob keepContent;
+	private Blob problem;
+	private Blob tryContent;
 
-	public KptFootprint(FootprintParam.Create footprintParam, Blob KEEP, Blob PROBLEM, Blob TRY) {
+	public KptFootprint(FootprintParam.Create footprintParam, Blob keepContent, Blob problem, Blob tryContent) {
 		super(footprintParam);
-		this.KEEP = KEEP;
-		this.PROBLEM = PROBLEM;
-		this.TRY = TRY;
+		this.keepContent = keepContent;
+		this.problem = problem;
+		this.tryContent = tryContent;
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/Tag.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Tag.java
@@ -1,0 +1,24 @@
+package me.ajaja.module.footprint.domain;
+
+import java.beans.ConstructorProperties;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import me.ajaja.global.common.SelfValidating;
+
+@Getter
+public class Tag extends SelfValidating<Tag> {
+	@NotNull
+	private final Long tagId;
+
+	@NotBlank
+	private final String tagName;
+
+	@ConstructorProperties({"tag", "tagName"})
+	public Tag(Long tagId, String tagName) {
+		this.tagId = tagId;
+		this.tagName = tagName;
+		this.validateSelf();
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/Tag.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Tag.java
@@ -4,6 +4,7 @@ import java.beans.ConstructorProperties;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import me.ajaja.global.common.SelfValidating;
 
@@ -13,6 +14,7 @@ public class Tag extends SelfValidating<Tag> {
 	private final Long tagId;
 
 	@NotBlank
+	@Size(max = 10)
 	private final String tagName;
 
 	@ConstructorProperties({"tag", "tagName"})

--- a/src/main/java/me/ajaja/module/footprint/domain/Tag.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Tag.java
@@ -11,16 +11,16 @@ import me.ajaja.global.common.SelfValidating;
 @Getter
 public class Tag extends SelfValidating<Tag> {
 	@NotNull
-	private final Long tagId;
+	private final Long id;
 
 	@NotBlank
 	@Size(max = 10)
-	private final String tagName;
+	private final String name;
 
-	@ConstructorProperties({"tag", "tagName"})
-	public Tag(Long tagId, String tagName) {
-		this.tagId = tagId;
-		this.tagName = tagName;
+	@ConstructorProperties({"id", "name"})
+	public Tag(Long id, String name) {
+		this.id = id;
+		this.name = name;
 		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/Target.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Target.java
@@ -9,17 +9,17 @@ import lombok.Getter;
 import me.ajaja.global.common.SelfValidating;
 
 @Getter
-public class TargetPlan extends SelfValidating<TargetPlan> {
+public class Target extends SelfValidating<Target> {
 	@NotNull
-	private final Long targetPlanId;
+	private final Long id;
 
 	@NotBlank
 	@Size(max = 20)
 	private final String title;
 
-	@ConstructorProperties({"targetPlanId", "title"})
-	public TargetPlan(Long targetPlanId, String title) {
-		this.targetPlanId = targetPlanId;
+	@ConstructorProperties({"id", "title"})
+	public Target(Long id, String title) {
+		this.id = id;
 		this.title = title;
 		this.validateSelf();
 	}

--- a/src/main/java/me/ajaja/module/footprint/domain/TargetPlan.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/TargetPlan.java
@@ -1,0 +1,19 @@
+package me.ajaja.module.footprint.domain;
+
+import java.beans.ConstructorProperties;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import me.ajaja.global.common.SelfValidating;
+
+@Getter
+public class TargetPlan extends SelfValidating<TargetPlan> {
+	@NotNull
+	private final Long targetPlanId;
+
+	@ConstructorProperties("targetPlanId")
+	public TargetPlan(Long targetPlanId) {
+		this.targetPlanId = targetPlanId;
+		this.validateSelf();
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/TargetPlan.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/TargetPlan.java
@@ -2,7 +2,9 @@ package me.ajaja.module.footprint.domain;
 
 import java.beans.ConstructorProperties;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import me.ajaja.global.common.SelfValidating;
 
@@ -11,9 +13,14 @@ public class TargetPlan extends SelfValidating<TargetPlan> {
 	@NotNull
 	private final Long targetPlanId;
 
-	@ConstructorProperties("targetPlanId")
-	public TargetPlan(Long targetPlanId) {
+	@NotBlank
+	@Size(max = 20)
+	private final String title;
+
+	@ConstructorProperties({"targetPlanId", "title"})
+	public TargetPlan(Long targetPlanId, String title) {
 		this.targetPlanId = targetPlanId;
+		this.title = title;
 		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/domain/Title.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Title.java
@@ -1,0 +1,21 @@
+package me.ajaja.module.footprint.domain;
+
+import java.beans.ConstructorProperties;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import me.ajaja.global.common.SelfValidating;
+
+@Getter
+public class Title extends SelfValidating<Title> {
+	@NotBlank
+	@Size(max = 50)
+	private final String title;
+
+	@ConstructorProperties("title")
+	public Title(String title) {
+		this.title = title;
+		this.validateSelf();
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/Writer.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Writer.java
@@ -1,0 +1,23 @@
+package me.ajaja.module.footprint.domain;
+
+import java.beans.ConstructorProperties;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import me.ajaja.global.common.SelfValidating;
+
+@Getter
+public class Writer extends SelfValidating<Writer> {
+	@NotNull
+	private final Long userId;
+
+	@NotBlank
+	private final String nickname;
+
+	@ConstructorProperties({"userId", "nickname"})
+	public Writer(Long userId, String nickname) {
+		this.userId = userId;
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/domain/Writer.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Writer.java
@@ -11,15 +11,15 @@ import me.ajaja.global.common.SelfValidating;
 @Getter
 public class Writer extends SelfValidating<Writer> {
 	@NotNull
-	private final Long userId;
+	private final Long id;
 
 	@NotBlank
 	@Size(max = 20)
 	private final String nickname;
 
-	@ConstructorProperties({"userId", "nickname"})
-	public Writer(Long userId, String nickname) {
-		this.userId = userId;
+	@ConstructorProperties({"id", "nickname"})
+	public Writer(Long id, String nickname) {
+		this.id = id;
 		this.nickname = nickname;
 		this.validateSelf();
 	}

--- a/src/main/java/me/ajaja/module/footprint/domain/Writer.java
+++ b/src/main/java/me/ajaja/module/footprint/domain/Writer.java
@@ -4,6 +4,7 @@ import java.beans.ConstructorProperties;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import me.ajaja.global.common.SelfValidating;
 
@@ -13,11 +14,13 @@ public class Writer extends SelfValidating<Writer> {
 	private final Long userId;
 
 	@NotBlank
+	@Size(max = 20)
 	private final String nickname;
 
 	@ConstructorProperties({"userId", "nickname"})
 	public Writer(Long userId, String nickname) {
 		this.userId = userId;
 		this.nickname = nickname;
+		this.validateSelf();
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
+++ b/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import lombok.Data;
 import me.ajaja.module.footprint.domain.Ajaja;
 import me.ajaja.module.footprint.domain.Footprint;
+import me.ajaja.module.footprint.domain.FootprintStatus;
 import me.ajaja.module.footprint.domain.Tag;
 import me.ajaja.module.footprint.domain.TargetPlan;
 import me.ajaja.module.footprint.domain.Title;
@@ -19,7 +20,7 @@ public final class FootprintParam {
 
 		private Title title;
 		private Footprint.Type type;
-		private Footprint.Visibility visibility;
+		private FootprintStatus footprintStatus;
 
 		private Set<Tag> tags;
 		private List<Ajaja> ajajas;

--- a/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
+++ b/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
@@ -1,0 +1,27 @@
+package me.ajaja.module.footprint.dto;
+
+import java.util.List;
+import java.util.Set;
+
+import lombok.Data;
+import me.ajaja.module.footprint.domain.Ajaja;
+import me.ajaja.module.footprint.domain.Footprint;
+import me.ajaja.module.footprint.domain.Tag;
+import me.ajaja.module.footprint.domain.TargetPlan;
+import me.ajaja.module.footprint.domain.Title;
+import me.ajaja.module.footprint.domain.Writer;
+
+public final class FootprintParam {
+	@Data
+	public static class Create {
+		private final TargetPlan targetPlan;
+		private final Writer writer;
+
+		private Title title;
+		private Footprint.Type type;
+		private Footprint.Visibility visibility;
+
+		private Set<Tag> tags;
+		private List<Ajaja> ajajas;
+	}
+}

--- a/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
+++ b/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
@@ -9,14 +9,14 @@ import me.ajaja.module.footprint.domain.Ajaja;
 import me.ajaja.module.footprint.domain.Footprint;
 import me.ajaja.module.footprint.domain.FootprintStatus;
 import me.ajaja.module.footprint.domain.Tag;
-import me.ajaja.module.footprint.domain.TargetPlan;
+import me.ajaja.module.footprint.domain.Target;
 import me.ajaja.module.footprint.domain.Title;
 import me.ajaja.module.footprint.domain.Writer;
 
 public final class FootprintParam {
 	@Data
 	public static class Create {
-		private final TargetPlan targetPlan;
+		private final Target targetPlan;
 		private final Writer writer;
 
 		private final Title title;
@@ -27,7 +27,7 @@ public final class FootprintParam {
 		private final List<Ajaja> ajajas;
 
 		@ConstructorProperties({"targetPlan", "writer", "title", "type", "footprintStatus", "tags", "ajajas"})
-		public Create(TargetPlan targetPlan, Writer writer, Title title, Footprint.Type type,
+		public Create(Target targetPlan, Writer writer, Title title, Footprint.Type type,
 			FootprintStatus footprintStatus, Set<Tag> tags, List<Ajaja> ajajas
 		) {
 			this.targetPlan = targetPlan;

--- a/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
+++ b/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
@@ -1,13 +1,9 @@
 package me.ajaja.module.footprint.dto;
 
 import java.beans.ConstructorProperties;
-import java.util.List;
 import java.util.Set;
 
 import lombok.Data;
-import me.ajaja.module.footprint.domain.Ajaja;
-import me.ajaja.module.footprint.domain.Footprint;
-import me.ajaja.module.footprint.domain.FootprintStatus;
 import me.ajaja.module.footprint.domain.Tag;
 import me.ajaja.module.footprint.domain.Target;
 import me.ajaja.module.footprint.domain.Title;
@@ -16,27 +12,19 @@ import me.ajaja.module.footprint.domain.Writer;
 public final class FootprintParam {
 	@Data
 	public static class Create {
-		private final Target targetPlan;
+		private final Target target;
 		private final Writer writer;
-
 		private final Title title;
-		private final Footprint.Type type;
-		private final FootprintStatus footprintStatus;
-
+		private final boolean visible;
 		private final Set<Tag> tags;
-		private final List<Ajaja> ajajas;
 
-		@ConstructorProperties({"targetPlan", "writer", "title", "type", "footprintStatus", "tags", "ajajas"})
-		public Create(Target targetPlan, Writer writer, Title title, Footprint.Type type,
-			FootprintStatus footprintStatus, Set<Tag> tags, List<Ajaja> ajajas
-		) {
-			this.targetPlan = targetPlan;
+		@ConstructorProperties({"target", "writer", "title", "visible", "tags"})
+		public Create(Target target, Writer writer, Title title, boolean visible, Set<Tag> tags) {
+			this.target = target;
 			this.writer = writer;
 			this.title = title;
-			this.type = type;
-			this.footprintStatus = footprintStatus;
+			this.visible = visible;
 			this.tags = tags;
-			this.ajajas = ajajas;
 		}
 	}
 }

--- a/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
+++ b/src/main/java/me/ajaja/module/footprint/dto/FootprintParam.java
@@ -1,5 +1,6 @@
 package me.ajaja.module.footprint.dto;
 
+import java.beans.ConstructorProperties;
 import java.util.List;
 import java.util.Set;
 
@@ -18,11 +19,24 @@ public final class FootprintParam {
 		private final TargetPlan targetPlan;
 		private final Writer writer;
 
-		private Title title;
-		private Footprint.Type type;
-		private FootprintStatus footprintStatus;
+		private final Title title;
+		private final Footprint.Type type;
+		private final FootprintStatus footprintStatus;
 
-		private Set<Tag> tags;
-		private List<Ajaja> ajajas;
+		private final Set<Tag> tags;
+		private final List<Ajaja> ajajas;
+
+		@ConstructorProperties({"targetPlan", "writer", "title", "type", "footprintStatus", "tags", "ajajas"})
+		public Create(TargetPlan targetPlan, Writer writer, Title title, Footprint.Type type,
+			FootprintStatus footprintStatus, Set<Tag> tags, List<Ajaja> ajajas
+		) {
+			this.targetPlan = targetPlan;
+			this.writer = writer;
+			this.title = title;
+			this.type = type;
+			this.footprintStatus = footprintStatus;
+			this.tags = tags;
+			this.ajajas = ajajas;
+		}
 	}
 }

--- a/src/test/java/me/ajaja/module/footprint/domain/FootprintTest.java
+++ b/src/test/java/me/ajaja/module/footprint/domain/FootprintTest.java
@@ -1,13 +1,13 @@
 package me.ajaja.module.footprint.domain;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
-
-import java.sql.Blob;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import jakarta.validation.ConstraintViolationException;
 import me.ajaja.common.support.MonkeySupport;
 import me.ajaja.module.footprint.dto.FootprintParam;
 
@@ -23,34 +23,41 @@ class FootprintTest extends MonkeySupport {
 		.build();
 
 	@Nested
-	@DisplayName("유형별 발자취 도메인 생성을 성공한다")
+	@DisplayName("조건에 맞는 입력 값에 따라 유형별 발자취 도메인 생성에 성공 한다.")
 	class CreateFootprintTest {
 		@Test
-		@DisplayName("자유 형식 발자취 도메인 생성을 성공한다.")
-		public void createFreeFootprint_Success_WithNoException() {
-			assertThatNoException().isThrownBy(
-				() -> {
-					FootprintParam.Create createParam = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
-					Blob content = fixtureMonkey.giveMeOne(Blob.class);
+		@DisplayName("자유 형식 발자취 도메인 생성에 성공 한다.")
+		void create_FreeFootprint_Success_WithNoException() {
+			FootprintParam.Create param = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
+			String content = "content";
 
-					FreeFootprint freeFootprint = new FreeFootprint(createParam, content);
-				}
-			);
+			assertThatNoException().isThrownBy(() -> {
+				FootprintFactory.createFreeFootprint(param, content);
+			});
 		}
 
 		@Test
-		@DisplayName("KPT 형식 발자취 도메인 생성을 성공한다.")
-		public void createKptFootprint_Success_WithNoException() {
-			assertThatNoException().isThrownBy(
-				() -> {
-					FootprintParam.Create createParam = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
-					Blob keepContent = fixtureMonkey.giveMeOne(Blob.class);
-					Blob problemContent = fixtureMonkey.giveMeOne(Blob.class);
-					Blob tryContent = fixtureMonkey.giveMeOne(Blob.class);
+		@DisplayName("KPT 형식 발자취 도메인 생성에 성공 한다.")
+		void create_KptFootprint_Success_WithNoException() {
+			FootprintParam.Create param = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
+			String keepContent = "keepContent";
+			String problemContent = "problemContent";
+			String tryContent = "tryContent";
 
-					KptFootprint kptFootprint = new KptFootprint(createParam, keepContent, problemContent, tryContent);
-				}
-			);
+			assertThatNoException().isThrownBy(() -> {
+				FootprintFactory.createkptFootprint(param, keepContent, problemContent, tryContent);
+			});
 		}
+	}
+
+	@Test
+	@DisplayName("발자취 항목에 대한 값이 null 일 때 예외가 발생 한다.")
+	void create_Fail_ByNoneContnets() {
+		FootprintParam.Create param = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
+		String content = null;
+
+		assertThatExceptionOfType(ConstraintViolationException.class).isThrownBy(
+			() -> FootprintFactory.createFreeFootprint(param, content)
+		);
 	}
 }

--- a/src/test/java/me/ajaja/module/footprint/domain/FootprintTest.java
+++ b/src/test/java/me/ajaja/module/footprint/domain/FootprintTest.java
@@ -1,0 +1,56 @@
+package me.ajaja.module.footprint.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.sql.Blob;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import me.ajaja.common.support.MonkeySupport;
+import me.ajaja.module.footprint.dto.FootprintParam;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.ConstructorPropertiesArbitraryIntrospector;
+import com.navercorp.fixturemonkey.jakarta.validation.plugin.JakartaValidationPlugin;
+
+class FootprintTest extends MonkeySupport {
+	private final FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+		.objectIntrospector(ConstructorPropertiesArbitraryIntrospector.INSTANCE)
+		.plugin(new JakartaValidationPlugin())
+		.defaultNotNull(true)
+		.build();
+
+	@Nested
+	@DisplayName("유형별 발자취 도메인 생성을 성공한다")
+	class CreateFootprintTest {
+		@Test
+		@DisplayName("자유 형식 발자취 도메인 생성을 성공한다.")
+		public void createFreeFootprint_Success_WithNoException() {
+			assertThatNoException().isThrownBy(
+				() -> {
+					FootprintParam.Create createParam = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
+					Blob content = fixtureMonkey.giveMeOne(Blob.class);
+
+					FreeFootprint freeFootprint = new FreeFootprint(createParam, content);
+				}
+			);
+		}
+
+		@Test
+		@DisplayName("KPT 형식 발자취 도메인 생성을 성공한다.")
+		public void createKptFootprint_Success_WithNoException() {
+			assertThatNoException().isThrownBy(
+				() -> {
+					FootprintParam.Create createParam = fixtureMonkey.giveMeOne(FootprintParam.Create.class);
+					Blob keepContent = fixtureMonkey.giveMeOne(Blob.class);
+					Blob problemContent = fixtureMonkey.giveMeOne(Blob.class);
+					Blob tryContent = fixtureMonkey.giveMeOne(Blob.class);
+
+					KptFootprint kptFootprint = new KptFootprint(createParam, keepContent, problemContent, tryContent);
+				}
+			);
+		}
+	}
+}


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 발자취 도메인 객체를 설계했습니다.

- 도메인 규칙까진 구현하지 않고 필요한 객체와 관계만 표현했습니다.
- 혼자만의 고민이 길어지는 것 같아 PR 단위를 짧게 해서 소통해야할 필요성을 느꼈습니다.
- 논의가 이뤄진 후 하나의 도메인 규칙을  PR 단위로 해서 작성하려 합니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 다양한 형식의 회고를 추상 클래스에서 상속받는 방식으로 구현했습니다. 

- 추상 클래스 제약으로 인해 정적 메서드를 사용해서 생성하는 방식을 보류하고 생성자를 사용하고 있습니다.
- 생성자에 파라미터가 많아 별도의 파라미터 DTO를 만들고 사용자 정의 생성자를 만들었습니다.
   다만 fixture-monkey의 장점을 통해 테스트 코드를 작성하려다보니 다소 dto에 새로운 생성자를 추가하는 어색함이 있습니다.
- Monkey support의 fixture monkey 사용 시 이상하게 생성자를 통한 방식이 적용되지 않았습니다. 테스트 및 조사 결과 
   FailoverIntrospector를 삭제하고 ConstructorPropertiesArbitraryIntrospector 만 적용했을 시 됩니다. 
   저는 필드값이 많아  반드시 Fixture Monkey를 사용하고 싶었고 공통 설정을 변경할 수 없어 테스트 코드의 멤버변수로  Fixture Monkey를 하 나 더 추가 했습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] createFreeFootprint_Success_WithNoException
- [x] createKPTFootprint_Success_WithNoException

<!-- 관련 이슈
프론트에서 작성해준 이슈와 연관되는 PR이라면 
주석을 풀고 작성해주세요! --> 


[//]: # (# 🫡 관련 Issue )
