### PR TITLE
Merge: add discord bot, fix feign client configuration error

### DIFF
--- a/jacoco-exclude-class
+++ b/jacoco-exclude-class
@@ -10,6 +10,7 @@ exclude me/ajaja/global/security/common/*
 exclude me/ajaja/global/security/filter/AuthorizationExceptionFilter
 exclude me/ajaja/global/security/jwt/JwtSecretProvider
 exclude me/ajaja/global/util/*
+exclude me/ajaja/infra/discord/*
 exclude me/ajaja/infra/feign/common/*
 exclude me/ajaja/infra/feign/kakao/client/*
 exclude me/ajaja/infra/feign/kakao/model/*

--- a/src/main/java/me/ajaja/AjajaApplication.java
+++ b/src/main/java/me/ajaja/AjajaApplication.java
@@ -7,13 +7,18 @@ import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import me.ajaja.infra.discord.DiscordProperties;
 import me.ajaja.infra.feign.kakao.client.KakaoProperties;
 import me.ajaja.infra.feign.ncp.client.NaverCloudProperties;
 
 @EnableAsync(proxyTargetClass = true)
 @EnableCaching
 @EnableScheduling
-@EnableConfigurationProperties(value = {NaverCloudProperties.class, KakaoProperties.class})
+@EnableConfigurationProperties(value = {
+	NaverCloudProperties.class,
+	KakaoProperties.class,
+	DiscordProperties.class
+})
 @SpringBootApplication
 public class AjajaApplication {
 	public static void main(String[] args) {

--- a/src/main/java/me/ajaja/global/common/DiscordEvent.java
+++ b/src/main/java/me/ajaja/global/common/DiscordEvent.java
@@ -1,0 +1,10 @@
+package me.ajaja.global.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class DiscordEvent {
+	private final String message;
+}

--- a/src/main/java/me/ajaja/global/config/OpenFeignConfig.java
+++ b/src/main/java/me/ajaja/global/config/OpenFeignConfig.java
@@ -13,6 +13,7 @@ import me.ajaja.infra.feign.common.FeignResponseEncoder;
 @Configuration
 @EnableFeignClients("me.ajaja.infra.feign")
 public class OpenFeignConfig {
+	public static final String DEFINED_ON_RUNTIME = "ajaja.me";
 
 	@Bean
 	ErrorDecoder errorDecoder() {

--- a/src/main/java/me/ajaja/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/me/ajaja/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package me.ajaja.global.exception;
 import static me.ajaja.global.exception.ErrorCode.*;
 import static org.springframework.http.HttpStatus.*;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -13,11 +14,15 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import com.fasterxml.jackson.databind.JsonMappingException;
 
 import jakarta.validation.ConstraintViolationException;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+	private final ApplicationEventPublisher eventPublisher;
+
 	@ExceptionHandler(AjajaException.class)
 	public ResponseEntity<ErrorResponse> handleAjajaException(AjajaException exception) {
 		final ErrorCode errorCode = exception.getErrorCode();
@@ -51,6 +56,7 @@ public class GlobalExceptionHandler {
 	@ResponseStatus(INTERNAL_SERVER_ERROR)
 	public ErrorResponse handleUnexpectedException(RuntimeException exception) {
 		log.warn("UnexpectedException Occurs : {}", exception.getMessage());
+		eventPublisher.publishEvent(new UnexpectedExceptionEvent(exception.getMessage()));
 		return ErrorResponse.from(AJAJA_SERVER_ERROR);
 	}
 }

--- a/src/main/java/me/ajaja/global/exception/UnexpectedExceptionEvent.java
+++ b/src/main/java/me/ajaja/global/exception/UnexpectedExceptionEvent.java
@@ -1,0 +1,9 @@
+package me.ajaja.global.exception;
+
+import me.ajaja.global.common.DiscordEvent;
+
+public class UnexpectedExceptionEvent extends DiscordEvent {
+	public UnexpectedExceptionEvent(String message) {
+		super("@everyone " + message);
+	}
+}

--- a/src/main/java/me/ajaja/infra/discord/DiscordEventListener.java
+++ b/src/main/java/me/ajaja/infra/discord/DiscordEventListener.java
@@ -1,0 +1,36 @@
+package me.ajaja.infra.discord;
+
+import java.util.Map;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import me.ajaja.global.common.DiscordEvent;
+import me.ajaja.infra.feign.discord.client.DiscordNotificationFeignClient;
+
+@Component
+@RequiredArgsConstructor
+class DiscordEventListener {
+	private final DiscordNotificationFeignClient discordNotificationFeignClient;
+	private final DiscordProperties discordProperties;
+	private final ObjectMapper mapper;
+
+	@Async
+	@EventListener
+	public void onDiscordEvent(DiscordEvent discordEvent) {
+		discordNotificationFeignClient.send(discordProperties.webHookUri(), toJson(discordEvent.getMessage()));
+	}
+
+	private String toJson(String rawMessage) {
+		try {
+			return mapper.writeValueAsString(Map.of("content", rawMessage));
+		} catch (JsonProcessingException exception) {
+			throw new RuntimeException(exception);
+		}
+	}
+}

--- a/src/main/java/me/ajaja/infra/discord/DiscordProperties.java
+++ b/src/main/java/me/ajaja/infra/discord/DiscordProperties.java
@@ -1,0 +1,25 @@
+package me.ajaja.infra.discord;
+
+import java.net.URI;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "secret.discord")
+public class DiscordProperties {
+	private static URI webHookUri; // lazy initializing
+
+	private final String webHook;
+
+	URI webHookUri() {
+		if (webHookUri == null) {
+			webHookUri = URI.create(webHook);
+		}
+
+		return webHookUri;
+	}
+}

--- a/src/main/java/me/ajaja/infra/feign/common/FeignErrorDecoder.java
+++ b/src/main/java/me/ajaja/infra/feign/common/FeignErrorDecoder.java
@@ -2,7 +2,9 @@ package me.ajaja.infra.feign.common;
 
 import static me.ajaja.global.exception.ErrorCode.*;
 
+import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 
 import feign.Response;
 import feign.RetryableException;
@@ -38,14 +40,10 @@ public class FeignErrorDecoder implements ErrorDecoder {
 		String responseBody = feignResponseEncoder.encodeResponseBody(response.body());
 
 		log.info("[Feign] API Request Fail To {} By '{}'.", response.request().url(), response.reason());
-		log.info("[Feign] Failed Request Header -> timestamp : {}",
-			response.request().headers().get("x-ncp-apigw-timestamp"));
-		log.info("[Feign] Failed Request Header -> accessKey : {}",
-			response.request().headers().get("x-ncp-iam-access-key"));
-		log.info("[Feign] Failed Request Header -> signature : {}",
-			response.request().headers().get("x-ncp-apigw-signature-v2"));
+		logHeaders(response.request().headers());
+
 		log.info("[Feign] Failed Request Body : {}", requestBody);
-		log.info("[Feign] Response From API : {}", responseBody);
+		log.info("[Feign] API Response : {}", responseBody);
 
 		return new AjajaException(EXTERNAL_API_FAIL);
 	}
@@ -60,5 +58,9 @@ public class FeignErrorDecoder implements ErrorDecoder {
 			new Date(System.currentTimeMillis()),
 			response.request()
 		);
+	}
+
+	private void logHeaders(Map<String, Collection<String>> headers) {
+		headers.forEach((key, value) -> log.info("[Feign] Failed Header -> {} : {}", key, value.toString()));
 	}
 }

--- a/src/main/java/me/ajaja/infra/feign/discord/client/DiscordNotificationFeignClient.java
+++ b/src/main/java/me/ajaja/infra/feign/discord/client/DiscordNotificationFeignClient.java
@@ -1,0 +1,16 @@
+package me.ajaja.infra.feign.discord.client;
+
+import static me.ajaja.global.config.OpenFeignConfig.*;
+import static org.springframework.http.MediaType.*;
+
+import java.net.URI;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "discord-send-notification", url = DEFINED_ON_RUNTIME)
+public interface DiscordNotificationFeignClient {
+	@PostMapping(consumes = APPLICATION_JSON_VALUE)
+	void send(URI webHookUri, @RequestBody String message);
+}

--- a/src/main/java/me/ajaja/infra/feign/ncp/client/NaverFeignHeaderConfiguration.java
+++ b/src/main/java/me/ajaja/infra/feign/ncp/client/NaverFeignHeaderConfiguration.java
@@ -11,14 +11,12 @@ import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Component;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import lombok.RequiredArgsConstructor;
 import me.ajaja.global.common.TimeValue;
 
-@Component
 @RequiredArgsConstructor
 class NaverFeignHeaderConfiguration {
 	private static final String EPOCH_TIME_HEADER = "x-ncp-apigw-timestamp";

--- a/src/main/resources/application-secret.yml
+++ b/src/main/resources/application-secret.yml
@@ -13,3 +13,6 @@ secret:
     service-id: ENC(KGYbqFQjZW4xYno34IweG24a6Zz+3XirLecUbQ3JyNGCXe0H4UhjP+RIW8JsDdQA)
     access-key: ENC(SPmlxNClw9rBA7g9XT89qwOnG1ZCemEYm4DV9ps/Xtg=)
     secret-key: ENC(MpTl8HcBlRs4YifDssjdG3c2A7w3DZqHr4JkDXVN79tjbQuJ5dhZGyzg64132Q4KT+KAmMxQsBk=)
+
+  discord:
+    web-hook: ENC(QFf65mAlIC3ELqkpLnMOvRSIwkK8nvrcpOpQ8Gd8SlEMe8qN6kTy7Aln67tz1Ne8vLOes9LbszywDaNpI01QPJnqOST60PZTx/u0fUu2Ieh4jwh4bRwGQK/LN1xyEwNjcXsWqc6ZJOTjs2SXmyGEjR2xM4gXTIS2OHoxA13XOX/jZwRtT/qfxg==)

--- a/src/test/java/me/ajaja/infra/discord/DiscordEventListenerTest.java
+++ b/src/test/java/me/ajaja/infra/discord/DiscordEventListenerTest.java
@@ -1,0 +1,42 @@
+package me.ajaja.infra.discord;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+
+import me.ajaja.global.common.DiscordEvent;
+
+@SpringBootTest
+@RecordApplicationEvents
+class DiscordEventListenerTest {
+	@Autowired
+	private ApplicationEventPublisher eventPublisher;
+	@Autowired
+	private ApplicationEvents events; // autowire success, just IDE error
+
+	@MockBean
+	private DiscordEventListener discordEventListener;
+
+	@Test
+	@DisplayName("디스코드 이벤트 발행되면 이벤트를 잘 받아야 한다.")
+	void onDiscordEvent_Success() {
+		// given
+
+		// when
+		eventPublisher.publishEvent(new DiscordEvent("test"));
+
+		// then
+		long count = events.stream(DiscordEvent.class).count();
+		assertThat(count).isOne();
+
+		then(discordEventListener).should(times(1)).onDiscordEvent(any());
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -45,6 +45,9 @@ secret:
     access-key: thisisfortest
     secret-key: thisisfortest
 
+  discord:
+    web-hook: thisisfortest
+
 ses:
   credentials:
     access-key: thisisfortest


### PR DESCRIPTION
<!-- PR 내용
어떤 작업을 했는지 작성해주세요!
PR이 너무 크면 너무 많은 내용이 들어가겠죠? -->
# 🔍 어떤 PR인가요?
- 디스코드 봇에 알림을 보내는 기능을 추가했습니다.

<!-- 리뷰어에게
어떤 부분을 자세하게 리뷰할지 서술해주세요. -->
# 😋 To Reviewer
- 추후에 도입될 FCM을 대비하여 EDA를 구성했고, 현재는 치명적인 오류(Unexpected Exception)이 발생했을 때 알림을 받도록 해두었습니다.
- 나중에 신규 유저의 가입, 외부 API 호출 등에 대해서 봇으로 알림을 받을 예정입니다.
- feign에서 잘못된 빈 등록으로 인해서 모든 client가 naver header를 사용하는 것을 수정하였습니다.

<!-- 테스트 
반영한 테스트 메서드 이름과 어떤 테스트를 했는지 작성해주세요.
(ex. save_Fail_ByDuplicateEmail) -->
# ✅ 작성한 테스트
- [x] onDiscordEvent_Success